### PR TITLE
Button 컴포넌트 개발

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,10 +12,7 @@ const customJestConfig = {
   testPathIgnorePatterns: ['node_modules', '<rootDir>.*/public', '<rootDir>/.next/', 'cypress'],
   moduleDirectories: ['node_modules', '<rootDir>/'],
   testEnvironment: 'jest-environment-jsdom',
-  coveragePathIgnorePatterns: [
-    // NOTE - 테스트를 위한 wrapper component
-    '<rootDir>/src/test/ReactQueryWrapper.tsx',
-  ],
+  coveragePathIgnorePatterns: ['<rootDir>/src/test/*'],
 };
 
 module.exports = async () => ({

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,30 @@
+import { ButtonHTMLAttributes } from 'react';
+import styled from '@emotion/styled';
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement>;
+
+const Button = ({ children, ...rest }: Props) => {
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <StyledButton type="button" {...rest}>
+      {children}
+    </StyledButton>
+  );
+};
+
+export default Button;
+
+const StyledButton = styled.button`
+  all: unset;
+  cursor: pointer;
+  background-color: ${({ theme }) => theme.colors.black};
+  color: ${({ theme }) => theme.colors.white};
+  border-radius: 8px;
+  padding: 12px;
+  font-size: 1rem;
+  text-align: center;
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.gray3};
+  }
+`;

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -23,6 +23,11 @@ const StyledButton = styled.button`
   padding: 12px;
   font-size: 1rem;
   text-align: center;
+  transition: background-color 0.2s;
+
+  &:active {
+    background-color: ${({ theme }) => theme.colors.gray5};
+  }
 
   &:disabled {
     background-color: ${({ theme }) => theme.colors.gray3};

--- a/src/components/button/Buttons.test.tsx
+++ b/src/components/button/Buttons.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import Button from './Button';
+
+import customRender from '@/test/customRender';
+
+const BUTTON_TEXT = 'foo bar';
+
+describe('button', () => {
+  it('children을 렌더링해야 한다', () => {
+    customRender(<Button>{BUTTON_TEXT}</Button>);
+    expect(screen.getByText(BUTTON_TEXT)).toBeInTheDocument();
+  });
+
+  it('onClick이 정상적으로 동작해야 한다', () => {
+    const onClickMock = jest.fn();
+    customRender(<Button onClick={onClickMock}>{BUTTON_TEXT}</Button>);
+
+    fireEvent.click(screen.getByText(BUTTON_TEXT));
+    expect(onClickMock).toBeCalledTimes(1);
+  });
+});

--- a/src/components/button/ContainedButton.tsx
+++ b/src/components/button/ContainedButton.tsx
@@ -1,0 +1,42 @@
+import { ComponentProps } from 'react';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Button from './Button';
+
+interface Props extends ComponentProps<typeof Button> {
+  /**
+   * @type 'medium' | 'large'
+   *
+   * @default 'medium'
+   */
+  size?: 'medium' | 'large';
+}
+
+const ContainedButton = ({ children, size = 'medium', ...rest }: Props) => {
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <StyledContainedButton size={size} {...rest}>
+      {children}
+    </StyledContainedButton>
+  );
+};
+
+export default ContainedButton;
+
+type StyledContainedButtonProps = Required<Pick<Props, 'size'>>;
+
+const StyledContainedButton = styled(Button)<StyledContainedButtonProps>`
+  width: 100%;
+
+  ${({ size }) => size === 'medium' && mediumCss}
+  ${({ size }) => size === 'large' && largeCss}
+`;
+
+const mediumCss = css`
+  padding: 8px 0;
+`;
+
+const largeCss = css`
+  padding: 12px 0;
+`;

--- a/src/components/button/LabelButton.tsx
+++ b/src/components/button/LabelButton.tsx
@@ -31,6 +31,10 @@ const StyledLabelButton = styled(Button)<StyledLabelButtonProps>`
   background-color: inherit;
   color: ${({ theme }) => theme.colors.gray3};
 
+  &:active {
+    background-color: inherit;
+  }
+
   &:disabled {
     background-color: inherit;
     color: ${({ theme }) => theme.colors.gray5};

--- a/src/components/button/LabelButton.tsx
+++ b/src/components/button/LabelButton.tsx
@@ -1,0 +1,47 @@
+import { ComponentProps } from 'react';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Button from './Button';
+
+interface Props extends ComponentProps<typeof Button> {
+  /**
+   * @type 'small' | 'large'
+   *
+   * @default 'small'
+   */
+  size?: 'small' | 'large';
+}
+
+const LabelButton = ({ children, size = 'small', ...rest }: Props) => {
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <StyledLabelButton size={size} {...rest}>
+      {children}
+    </StyledLabelButton>
+  );
+};
+
+export default LabelButton;
+
+type StyledLabelButtonProps = Required<Pick<Props, 'size'>>;
+
+const StyledLabelButton = styled(Button)<StyledLabelButtonProps>`
+  padding: 8px;
+  background-color: inherit;
+  color: ${({ theme }) => theme.colors.gray3};
+
+  &:disabled {
+    background-color: inherit;
+    color: ${({ theme }) => theme.colors.gray5};
+  }
+
+  ${({ size }) => size === 'small' && smallCss}
+  ${({ size }) => size === 'large' && largeCss}
+`;
+
+const smallCss = css`
+  font-size: 12px;
+`;
+
+const largeCss = css``;

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -10,11 +10,11 @@ class MyDocument extends Document {
     return (
       <Html lang="ko">
         <Head>
-        <link
-  rel="stylesheet"
-  as="style"
-  href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
-/>
+          <link
+            rel="stylesheet"
+            as="style"
+            href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
+          />
           <meta charSet="utf-8" />
           <title>team3-web</title>
           {isProd(process.env.NODE_ENV) && (

--- a/src/pages/test/index.page.tsx
+++ b/src/pages/test/index.page.tsx
@@ -1,0 +1,30 @@
+import Button from '@/components/button/Button';
+import ContainedButton from '@/components/button/ContainedButton';
+import LabelButton from '@/components/button/LabelButton';
+
+const Test = () => {
+  return (
+    <div>
+      <Button>테스트 버튼</Button>
+
+      <ContainedButton size="medium">컨테인 버튼 medium</ContainedButton>
+      <ContainedButton size="medium" disabled>
+        컨테인 버튼 medium
+      </ContainedButton>
+
+      <ContainedButton size="large">컨테인 버튼 large</ContainedButton>
+      <ContainedButton size="large" disabled>
+        컨테인 버튼 large
+      </ContainedButton>
+
+      <LabelButton>라벨 버튼 small</LabelButton>
+      <LabelButton disabled>라벨 버튼 small</LabelButton>
+      <LabelButton size="large">라벨 버튼 large</LabelButton>
+      <LabelButton size="large" disabled>
+        라벨 버튼 large
+      </LabelButton>
+    </div>
+  );
+};
+
+export default Test;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -22,7 +22,7 @@ export const setGlobalStyles = css`
   }
 
   * {
-  font-family: inherit;
+    font-family: inherit;
   }
 `;
 

--- a/src/test/customRender.tsx
+++ b/src/test/customRender.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren, ReactElement } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+
+import MockTheme from './MockTheme';
+import ReactQueryWrapper from './ReactQueryWrapper';
+
+import theme from '@/styles/theme';
+
+const RenderWithAllProviders = ({ children }: PropsWithChildren) => {
+  return (
+    <ReactQueryWrapper>
+      <MockTheme theme={theme}>{children}</MockTheme>
+    </ReactQueryWrapper>
+  );
+};
+
+const customRender = (ui: ReactElement, options?: RenderOptions) => {
+  return render(ui, { wrapper: RenderWithAllProviders, ...options });
+};
+
+export default customRender;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

## 🎉 어떻게 해결했나요?

- Button 컴포넌트 개발
  - figma를 진실의 원천으로 삼아 `Button`, `ContainedButton`, `LabelButton`을 개발했어요
 


- 스토리북 없이 컴포넌트들을 볼 수 있는 임시 route `/test` 적용
  - 내부적으로 QA시에 사용하고 배포 전에 삭제하면 좋을 거 같아요

<img width="428" alt="스크린샷 2022-11-15 오전 9 10 15" src="https://user-images.githubusercontent.com/26461307/201794258-3b74c065-312f-40d0-a916-0b0a538a829a.png">


- 테스트 시에 `Provider`와 함께 렌더링 하는 `customRender` 유틸 개발
  - `src/test/*` 파일들 커버리지에서 제외




### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 

#20 에서 언급되는 `Icon` 관련 로직들은, 아이콘 컴포넌트 개발 이후에 새로운 이슈로 등록 후 개발할게요.

> ~~button active 시 스타일 받은 후 마저 작업해 볼게요~~

closes #20 