### PR TITLE
Chip 컴포넌트

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "search.exclude": {
+    "**/.yarn": true,
+    "**/.pnp.*": true
+  },
+  "eslint.nodePath": ".yarn/sdks",
+  "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "axios": "^0.27.2",
     "emotion-normalize": "^11.0.1",
     "framer-motion": "^7.5.1",
-    "next": "^13.0.2",
+    "next": "13.0.2",
     "next-compose-plugins": "^2.2.1",
     "qs": "^6.11.0",
     "react": "^18.2.0",

--- a/src/components/chip/Chip.test.tsx
+++ b/src/components/chip/Chip.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import Chip from './Chip';
+
+import theme from '@/styles/theme';
+import MockTheme from '@/test/MockTheme';
+
+describe('Chip', () => {
+  const onClick = jest.fn();
+
+  const renderChip = () =>
+    render(<Chip onClick={onClick} color={given.color} label="label" icon={given.icon} />, {
+      wrapper: MockTheme,
+    });
+
+  describe('onClick', () => {
+    context('chip을 클릭하면', () => {
+      it('onClick이 호출된다.', () => {
+        renderChip();
+
+        fireEvent.click(screen.getByTestId('chip-wrapper'));
+
+        expect(onClick).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('color', () => {
+    context('color가 default면', () => {
+      given('color', () => 'default');
+
+      it('배경색이 white이고, 글자색이 gray4이다.', () => {
+        renderChip();
+
+        expect(screen.getByTestId('chip-wrapper')).toHaveStyle({
+          backgroundColor: theme.colors.white,
+          color: theme.colors.gray4,
+        });
+      });
+    });
+
+    context('color가 black면', () => {
+      given('color', () => 'black');
+
+      it('배경색이 black이고, 글자색이 white이다.', () => {
+        renderChip();
+
+        expect(screen.getByTestId('chip-wrapper')).toHaveStyle({
+          backgroundColor: theme.colors.black,
+          color: theme.colors.white,
+        });
+      });
+    });
+  });
+
+  describe('icon', () => {
+    context('icon이 주어지면', () => {
+      given('icon', () => <div data-testid="icon" />);
+
+      it('icon이 보인다.', () => {
+        renderChip();
+
+        expect(screen.getByTestId('icon')).toBeInTheDocument();
+      });
+    });
+
+    context('icon이 주어지지 않으면', () => {
+      given('icon', () => null);
+
+      it('IconInfo가 보인다.', () => {
+        renderChip();
+
+        expect(screen.getByTestId('icon-info')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/chip/Chip.tsx
+++ b/src/components/chip/Chip.tsx
@@ -1,0 +1,48 @@
+import { FC, ReactNode } from 'react';
+import styled from '@emotion/styled';
+
+import IconInfo from '../icon/IconInfo';
+
+type Color = 'default' | 'black';
+
+interface Props {
+  label: string;
+  color?: Color;
+  icon?: ReactNode;
+  onClick?: () => void;
+}
+
+const Chip: FC<Props> = ({ label, color = 'default', icon, onClick }) => {
+  return (
+    <Wrapper color={color} onClick={onClick} data-testid="chip-wrapper">
+      {icon ?? <IconInfo width={16} height={16} viewBox="0 0 16 16" />}
+      <span>{label}</span>
+    </Wrapper>
+  );
+};
+
+export default Chip;
+
+const Wrapper = styled.span<{ color: Color }>(
+  {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: '8px 16px',
+    borderRadius: '50px',
+    '*:first-of-type': {
+      marginRight: '4px',
+    },
+  },
+  ({ theme, color }) => ({
+    ...theme.typographies.body1,
+    fontWeight: 500,
+    ...(color === 'default' && {
+      backgroundColor: theme.colors.white,
+      color: theme.colors.gray4,
+    }),
+    ...(color === 'black' && {
+      backgroundColor: theme.colors.black,
+      color: theme.colors.white,
+    }),
+  }),
+);

--- a/src/components/icon/IconInfo.tsx
+++ b/src/components/icon/IconInfo.tsx
@@ -1,0 +1,13 @@
+import Svg, { Props } from '../svg/Svg';
+
+const IconInfo = ({ ...rest }: Props) => (
+  <Svg {...rest} data-testid="icon-info">
+    <rect width="16" height="16" rx="4" fill="#E9E9EE" />
+    <path
+      d="M7.20741 14H8.79259V5.34661H7.20741V14ZM7 3.00398C7.00741 3.56175 7.45926 4.01594 8.00741 4.00797C8.54815 4.01594 9 3.56175 9 3.00398C9 2.44622 8.54815 2 8.00741 2C7.45926 2 7.00741 2.44622 7 3.00398Z"
+      fill="#C7C7D0"
+    />
+  </Svg>
+);
+
+export default IconInfo;

--- a/src/pages/test/index.page.tsx
+++ b/src/pages/test/index.page.tsx
@@ -6,6 +6,21 @@ import Button from '@/components/button/Button';
 import ContainedButton from '@/components/button/ContainedButton';
 import LabelButton from '@/components/button/LabelButton';
 import Checkbox from '@/components/checkbox/Checkbox';
+import Chip from '@/components/chip/Chip';
+import IconAdd from '@/components/icon/IconAdd';
+import IconCancel from '@/components/icon/IconCancel';
+import IconCancelSmall from '@/components/icon/IconCancelSmall';
+import IconCheckbox from '@/components/icon/IconCheckbox';
+import IconChevron20pxUpDown from '@/components/icon/IconChevron20pxUpDown';
+import IconChevron24pxRightLeft from '@/components/icon/IconChevron24pxRightLeft';
+import IconChevron24pxUpDown from '@/components/icon/IconChevron24pxUpDown';
+import IconHome from '@/components/icon/IconHome';
+import IconInfo from '@/components/icon/IconInfo';
+import IconMenu from '@/components/icon/IconMenu';
+import IconMovable from '@/components/icon/IconMovable';
+import IconOverflow from '@/components/icon/IconOverflow';
+import IconPin from '@/components/icon/IconPin';
+import IconSearch from '@/components/icon/IconSearch';
 
 const BottomSheet = dynamic(() => import('@/components/portal/BottomSheet'));
 
@@ -34,7 +49,6 @@ const Test = () => {
         라벨 버튼 large
       </LabelButton>
 
-
       <Heading>bottom sheet</Heading>
 
       <Button onClick={() => setIsOpen((prev) => !prev)}>bottom sheet 열기</Button>
@@ -51,6 +65,27 @@ const Test = () => {
             // 체크박스 체크 해제 시 실행할 내용 작성
           }}
         />
+      </div>
+      <div>
+        <IconAdd />
+        <IconCancel />
+        <IconCancelSmall />
+        <IconCheckbox />
+        <IconChevron20pxUpDown />
+        <IconChevron24pxRightLeft />
+        <IconChevron24pxUpDown />
+        <IconHome />
+        <IconMenu />
+        <IconMovable />
+        <IconOverflow />
+        <IconPin />
+        <IconSearch />
+        <IconInfo />
+      </div>
+      <div>
+        <Chip color="black" label="디프만 준비물" />
+        <Chip label="default" />
+        <Chip color="black" icon={<IconAdd />} label="text" />
       </div>
     </div>
   );


### PR DESCRIPTION
> IconInfo 24 x 24 디자이너분께서 만들어 주시면 대치할 예정이에요. 현재는 16 x 16

> 안녕하세요! 민규님 24px로 교체해두었습니다! 참고로 이 아이콘(Iconinfo)은 추후에 저희가 그린 별도의 그래픽이 들어갈 예정이라, 꼭 저걸 적용하지 않더라도 임시로 영역만 잡아서 작업해 주시면 감사하겠습니다 ㅜㅜ

우선 이대로 머지하고 추후에 대치하면 될것 같네요

## 🤔 해결하려는 문제가 무엇인가요?
- typescript version을 인식하지 못하여 sdk 다시 설치했어요.
- chip 컴포넌트 개발

## 🎉 어떻게 해결했나요?
- chip 컴포넌트의 기본 기능에 selected 가 없기에 mui 참고하여 만들었어요.
- color를 추상화하였어요.

<img width="376" alt="image" src="https://user-images.githubusercontent.com/32628358/202840718-33a75ec9-cd6a-4f42-b207-9eda9b95d5ef.png">

 