### PR TITLE
로컬 https 개발 환경 설정

### DIFF
--- a/httpsServer.js
+++ b/httpsServer.js
@@ -1,0 +1,26 @@
+const { createServer } = require('https');
+const { parse } = require('url');
+const next = require('next');
+const fs = require('fs');
+
+const port = 3000;
+const dev = process.env.NODE_ENV !== 'production';
+const app = next({ dev });
+const handle = app.getRequestHandler();
+
+const httpsOptions = {
+  key: fs.readFileSync('./localhost-key.pem'),
+  cert: fs.readFileSync('./localhost.pem'),
+};
+
+app.prepare().then(() => {
+  createServer(httpsOptions, (req, res) => {
+    const parsedUrl = parse(req.url, true);
+    handle(req, res, parsedUrl);
+  }).listen(port, (err) => {
+    if (err) throw err;
+
+    // eslint-disable-next-line no-console
+    console.log(`ready - started server on url: https://localhost:${port}`);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "depromeet-12th-ahmatda-team",
   "scripts": {
     "dev": "next dev",
+    "dev:https": "node httpsServer.js",
     "dev:turbo": "next dev --turbo",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
closes #50


## 🎉 어떻게 해결했나요?
- `mkcert` 사용

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 

## :fire: 필독 - 사용 방법

### 1. mkcert 설치

```bash
brew install mkcert
mkcert -install
```

### 2. pem 파일 생성

```bash
# 프로젝트 루트에서

mkcert localhost
```

이후 루트에 아래 파일들이 생겨야 합니다

![스크린샷 2022-11-20 오후 6 25 51](https://user-images.githubusercontent.com/26461307/202894735-f5b25612-62cf-4aa4-b130-2dd6260a5691.png)

### 3. https dev 실행

```bash
yarn dev:https # https://localhost:3000

# 아래는 기존 명령어
yarn dev # http://localhost:3000
yarn dev:turbo # http://localhost:3000 + turbopack
```

---

iOS 시뮬 환경에서는 pem 파일을 넣으면 된다고 합니다