### PR TITLE
Carousel Indicator 동작 수정

### DIFF
--- a/src/components/carousel/Indicator.tsx
+++ b/src/components/carousel/Indicator.tsx
@@ -42,7 +42,7 @@ const Dot = styled.span<{ isSelected: boolean }>(
 export default Indicator;
 
 const useIndicator = ({ carouselWrapper }: Pick<Props, 'carouselWrapper'>) => {
-  const [currentIndex, setCurrentIndex] = useState<number>(0);
+  const [currentIndex, setCurrentIndex] = useState<number | null>(null);
 
   const throttledOnScroll = useMemo(
     () =>
@@ -57,13 +57,13 @@ const useIndicator = ({ carouselWrapper }: Pick<Props, 'carouselWrapper'>) => {
 
   useEffect(() => {
     if (!carouselWrapper) return;
-
+    throttledOnScroll();
     carouselWrapper.addEventListener('scroll', throttledOnScroll);
 
     return () => {
       carouselWrapper.removeEventListener('scroll', throttledOnScroll);
     };
-  }, []);
+  }, [throttledOnScroll]);
 
   return { currentIndex };
 };

--- a/src/components/carousel/Indicator.tsx
+++ b/src/components/carousel/Indicator.tsx
@@ -33,6 +33,7 @@ const Indicator = ({ carouselWrapper }: Props) => {
 
 const Wrapper = styled.div({
   height: '6px',
+  margin: '8px 0',
   display: 'flex',
   gap: '4px',
   justifyContent: 'center',

--- a/src/components/carousel/Indicator.tsx
+++ b/src/components/carousel/Indicator.tsx
@@ -1,13 +1,12 @@
-import { RefObject, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
 import throttle from 'lodash/throttle';
 
 interface Props {
-  carouselWrapperRef: RefObject<HTMLDivElement>;
+  carouselWrapper: HTMLDivElement | null;
 }
 
-const Indicator = ({ carouselWrapperRef }: Props) => {
-  const { current: carouselWrapper } = carouselWrapperRef;
+const Indicator = ({ carouselWrapper }: Props) => {
   const childrenLength = carouselWrapper ? carouselWrapper.childNodes.length : 0;
   const childrenIds = useMemo(() => Array.from(Array(childrenLength).keys()), [childrenLength]);
 
@@ -42,11 +41,7 @@ const Dot = styled.span<{ isSelected: boolean }>(
 
 export default Indicator;
 
-interface UseIndicatorProps {
-  carouselWrapper: HTMLDivElement | null;
-}
-
-const useIndicator = ({ carouselWrapper }: UseIndicatorProps) => {
+const useIndicator = ({ carouselWrapper }: Pick<Props, 'carouselWrapper'>) => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
 
   const throttledOnScroll = useMemo(

--- a/src/components/carousel/Indicator.tsx
+++ b/src/components/carousel/Indicator.tsx
@@ -3,6 +3,16 @@ import styled from '@emotion/styled';
 import throttle from 'lodash/throttle';
 
 interface Props {
+  /**
+   * @example
+   * ```tsx
+   * const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null);
+   *
+   * <Carousel.Wrapper ref={setWrapper}>
+   * </Carousel.Wrapper>
+   * <Indicator carouselWrapper={wrapper} />
+   * ```
+   */
   carouselWrapper: HTMLDivElement | null;
 }
 

--- a/src/pages/test/index.page.tsx
+++ b/src/pages/test/index.page.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
 
@@ -32,7 +32,7 @@ const BottomSheet = dynamic(() => import('@/components/portal/BottomSheet'));
 
 const Test = () => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  const carouselWrapperRef = useRef<HTMLDivElement>(null);
+  const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
 
   return (
     <>
@@ -68,7 +68,7 @@ const Test = () => {
         <Heading>Toggle</Heading>
         <ToggleSwitch />
       </div>
-      
+
       <div>
         <Heading>bottom sheet</Heading>
 
@@ -111,7 +111,7 @@ const Test = () => {
       <div>
         <Heading>carousel</Heading>
 
-        <Carousel.Wrapper ref={carouselWrapperRef}>
+        <Carousel.Wrapper ref={setCarouselWrapper}>
           <Carousel.Item>
             <TestDiv>a</TestDiv>
           </Carousel.Item>
@@ -122,9 +122,9 @@ const Test = () => {
             <TestDiv>c</TestDiv>
           </Carousel.Item>
         </Carousel.Wrapper>
-        <Indicator carouselWrapperRef={carouselWrapperRef} />
+        <Indicator carouselWrapper={carouselWrapper} />
       </div>
-      
+
       <div>
         <Heading>segment control</Heading>
         <SegmentedControl options={['요일별', '날짜별']} />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
1. ref 초기 값 때문에 Indicator가 렌더링되지 않음
2. (새로고침 등 후에) 이전에 스크롤 된 위치가 indicator에 반영되지 않음

## 🎉 어떻게 해결했나요?
1. callback ref 형태로 사용 방법 및 인터페이스 수정
  ```tsx
  const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null);

  <Carousel.Wrapper ref={setWrapper} />
  // ...
  <Indicator carouselWrapper={wrapper} />
  ```
  관련 아티클
  - [Ref objects inside useEffect Hooks](https://medium.com/@teh_builder/ref-objects-inside-useeffect-hooks-eb7c15198780)
  - [dan 트윗](https://twitter.com/dan_abramov/status/1093497348913803265?ref_src=twsrc%5Etfw)

2.  useIndicator의 effect에 스크롤 핸들러 실행 추가


- Indicator 기본 margin 추가

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 