### PR TITLE
Default AppBar 개발 및 적용

### DIFF
--- a/src/components/navigation/BottomNavigation.tsx
+++ b/src/components/navigation/BottomNavigation.tsx
@@ -62,7 +62,7 @@ const Wrapper = styled.section(
     left: 0,
     display: 'flex',
   },
-  ({ theme }) => ({ backgroundColor: theme.colors.white }),
+  ({ theme }) => ({ backgroundColor: theme.colors.white, borderTop: `1px solid ${theme.colors.gray1}` }),
 );
 
 const Anchor = styled(NextLink)({

--- a/src/components/navigation/DefaultAppBar.tsx
+++ b/src/components/navigation/DefaultAppBar.tsx
@@ -1,0 +1,53 @@
+import styled from '@emotion/styled';
+
+import IconMenu from '../icon/IconMenu';
+import IconPin from '../icon/IconPin';
+
+const DefaultAppBar = () => {
+  return (
+    <Wrapper>
+      <span>Logo</span>
+
+      <ButtonWrapper>
+        <Button>
+          <IconPin />
+        </Button>
+
+        <Button>
+          <IconMenu />
+        </Button>
+      </ButtonWrapper>
+    </Wrapper>
+  );
+};
+
+export default DefaultAppBar;
+
+const Wrapper = styled.section(
+  {
+    position: 'sticky',
+    top: '0',
+    left: '0',
+    width: '100%',
+    height: '48px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  ({ theme }) => ({ backgroundColor: theme.colors.gray1 }),
+);
+
+const ButtonWrapper = styled.div({
+  position: 'absolute',
+  top: '0',
+  right: '-12px',
+  height: '100%',
+});
+
+const Button = styled.button({
+  all: 'unset',
+  cursor: 'pointer',
+  width: '48px',
+  height: '48px',
+  textAlign: 'center',
+});

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import { NextPageWithLayout } from './_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
+import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 
 const HomePage: NextPageWithLayout = () => {
   return (
@@ -16,6 +17,7 @@ const HomePage: NextPageWithLayout = () => {
 HomePage.getLayout = function getLayout(page: ReactElement) {
   return (
     <>
+      <DefaultAppBar />
       {page}
       <BottomNavigation />
     </>

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -3,6 +3,7 @@ import { ReactElement } from 'react';
 import { NextPageWithLayout } from '../_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
+import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 
 const Template: NextPageWithLayout = () => {
   return <div>Template</div>;
@@ -11,6 +12,7 @@ const Template: NextPageWithLayout = () => {
 Template.getLayout = function getLayout(page: ReactElement) {
   return (
     <>
+      <DefaultAppBar />
       {page}
       <BottomNavigation />
     </>

--- a/src/pages/test/index.page.tsx
+++ b/src/pages/test/index.page.tsx
@@ -68,7 +68,7 @@ const Test = () => {
         <Heading>Toggle</Heading>
         <ToggleSwitch />
       </div>
-      
+
       <div>
         <Heading>bottom sheet</Heading>
 
@@ -124,7 +124,7 @@ const Test = () => {
         </Carousel.Wrapper>
         <Indicator carouselWrapperRef={carouselWrapperRef} />
       </div>
-      
+
       <div>
         <Heading>segment control</Heading>
         <SegmentedControl options={['요일별', '날짜별']} />

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -2,6 +2,8 @@ import React, { ReactElement } from 'react';
 import { css, Global } from '@emotion/react';
 import emotionNormalize from 'emotion-normalize';
 
+import theme from './theme';
+
 export const setGlobalStyles = css`
   ${emotionNormalize}
 
@@ -9,6 +11,8 @@ export const setGlobalStyles = css`
     font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI',
       'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
       sans-serif;
+    background-color: ${theme.colors.gray1};
+    color: ${theme.colors.black};
   }
 
   a {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
closes #51 


## 🎉 어떻게 해결했나요?
- `sticky` 포지션의 `DefaultAppBar` 컴포넌트를 개발했어요
  - 우측 버튼의 경우 조작 가능한 영역이 레이아웃 밖까지 있어서, `absolute` 포지션으로 적용했어요
  <img width="794" alt="스크린샷 2022-11-21 오후 12 08 55" src="https://user-images.githubusercontent.com/26461307/202954967-13057582-e4ac-4eb7-a0fd-1d414a716d30.png">

- `/`, `/template`의 레이아웃에 적용했어요

- 위 두 route에서 사용되는 배경 색, 폰트 색을 `body`에 적용했어요
  - 온보드와 같은 route는 대응이 필요해요 @hansol-FE 
### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 
- 버튼에 대한 로직은 분리해 적용할게요