### PR TITLE
온보딩 타이틀 section 개발

### DIFF
--- a/src/components/route-onboard/TitleSection.tsx
+++ b/src/components/route-onboard/TitleSection.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { m } from 'framer-motion';
+
+import { defaultFadeInVariants, staggerOne } from '@/constants/motions';
+
+interface OnboardTitleProps {
+  title: string;
+  subTitle: string;
+}
+
+const TitleSection = ({ title, subTitle }: OnboardTitleProps) => {
+  return (
+    <m.div variants={staggerOne} initial="initial" animate="animate" exit="exit">
+      <MainTitle dangerouslySetInnerHTML={{ __html: title }} variants={defaultFadeInVariants} />
+      <SubTitle variants={defaultFadeInVariants}>{subTitle}</SubTitle>
+    </m.div>
+  );
+};
+
+export default TitleSection;
+
+const MainTitle = styled(m.h1)`
+  ${({ theme }) => ({ ...theme.typographies.text1 })};
+  color: ${({ theme }) => theme.colors.gray6};
+`;
+const SubTitle = styled(m.h2)`
+  ${({ theme }) => ({ ...theme.typographies.caption1 })};
+  color: ${({ theme }) => theme.colors.gray4};
+`;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -23,6 +23,11 @@ const theme = {
       fontSize: '1rem',
       lineHeight: '1.5rem',
     },
+    text1: {
+      fontWeight: 500,
+      fontSize: '1.75rem',
+      lineHeight: '2.375rem',
+    },
     text2: {
       fontWeight: 400,
       fontSize: '0.75rem',
@@ -32,6 +37,11 @@ const theme = {
       fontWeight: 500,
       fontSize: '1.125rem',
       lineHeight: '1.75rem',
+    },
+    caption1: {
+      fontWeight: 500,
+      fontSize: '1rem',
+      lineHeight: '1.5rem',
     },
     caption2: {
       fontWeight: 500,


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- closes #71 

## 🎉 어떻게 해결했나요?
- `theme`에 tex1, caption1 typo 추가했어요
- 온보딩 상단 타이틀 섹션 개발했어요
  - 온보딩에서 공통으로 사용 할 섹션이에요
  - title에 큰글자 subTitle에 작은글자가 들어가요
 

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->