### PR TITLE
Dialog 컴포넌트 개발

### DIFF
--- a/src/components/portal/BottomSheet.tsx
+++ b/src/components/portal/BottomSheet.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { m, Variants } from 'framer-motion';
 
 import PortalWrapper from './PortalWrapper';
+import StyledMotionScrim from './StyledMotionScrim';
 
 import { defaultEasing, defaultFadeInVariants } from '@/constants/motions';
 import usePreventScroll from '@/hooks/scroll/usePreventScroll';
@@ -35,19 +36,6 @@ const BottomSheet = ({ setToClose, children, isShowing }: Props) => {
 };
 
 export default BottomSheet;
-
-const StyledMotionScrim = styled(m.div)`
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 900;
-
-  width: 100vw;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.3);
-
-  overflow: hidden;
-`;
 
 const StyledMotionContent = styled(m.div)`
   position: absolute;

--- a/src/components/portal/Dialog.tsx
+++ b/src/components/portal/Dialog.tsx
@@ -1,0 +1,156 @@
+import { ComponentProps, MouseEvent, ReactElement, ReactNode } from 'react';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { m } from 'framer-motion';
+
+import PortalWrapper from './PortalWrapper';
+import StyledMotionScrim from './StyledMotionScrim';
+
+import { defaultFadeInUpVariants, defaultFadeInVariants } from '@/constants/motions';
+import usePreventScroll from '@/hooks/scroll/usePreventScroll';
+
+type PortalWrapperPropsWithoutChildren = Omit<ComponentProps<typeof PortalWrapper>, 'children'>;
+
+interface Props extends PortalWrapperPropsWithoutChildren {
+  /**
+   * Dialog를 안보이게 할 callback
+   */
+  setToClose: VoidFunction;
+  /**
+   * 상단 영역에 들어갈 ReactNode
+   *
+   * wrapper에 flex, column center, gap 8px이 적용돼 있어요
+   *
+   * 기본적인 스타일은 `Dialog.ContentTitle`, `Dialog.ContentBody`를 사용할 수 있어요
+   */
+  content: ReactNode;
+  /**
+   * 하단 왼쪽에 들어갈 버튼
+   *
+   * 기본적인 스타일은 `Dialog.Button`, `Dialog.WarningButton`을 사용할 수 있어요
+   */
+  leftButton: ReactElement;
+  /**
+   * 하단 오른쪽에 들어갈 버튼
+   *
+   * 기본적인 스타일은 `Dialog.Button`, `Dialog.WarningButton`을 사용할 수 있어요
+   */
+  rightButton: ReactElement;
+}
+
+/**
+ * @example
+ *```tsx
+  <Dialog
+      isShowing={isShowing}
+      setToClose={close}
+      content={
+        <>
+          <Dialog.ContentTitle>진짜 닫을거?</Dialog.ContentTitle>
+          <Dialog.ContentBody>어쩌구 저쩌구</Dialog.ContentBody>
+        </>
+      }
+      leftButton={<Dialog.Button onClick={close}>닫기</Dialog.Button>}
+      rightButton={<Dialog.WarningButton onClick={close}>진짜 닫기</Dialog.WarningButton>}
+  />
+ *```
+ */
+const Dialog = ({ setToClose, isShowing, content, leftButton, rightButton }: Props) => {
+  usePreventScroll(isShowing);
+
+  const onClickScrim = (e: MouseEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
+    setToClose();
+  };
+
+  return (
+    <PortalWrapper isShowing={isShowing}>
+      <Scrim onClick={onClickScrim} variants={defaultFadeInVariants} initial="initial" animate="animate" exit="exit">
+        <MotionWrapper variants={defaultFadeInUpVariants}>
+          <ContentWrapper>{content}</ContentWrapper>
+          <ButtonWrapper>
+            {leftButton}
+            <HorizontalDivider />
+            {rightButton}
+          </ButtonWrapper>
+        </MotionWrapper>
+      </Scrim>
+    </PortalWrapper>
+  );
+};
+
+const Scrim = styled(StyledMotionScrim)({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+const MotionWrapper = styled(m.div)(
+  {
+    width: '17.5rem',
+    borderRadius: '16px',
+  },
+  ({ theme }) => ({
+    backgroundColor: theme.colors.white,
+  }),
+);
+
+const ContentWrapper = styled.div(
+  {
+    width: '100%',
+    padding: '24px 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: '8px',
+  },
+  ({ theme }) => ({ borderBottom: `1px solid ${theme.colors.gray2}` }),
+);
+
+const ButtonWrapper = styled.div({
+  width: '100%',
+  height: '56px',
+  display: 'flex',
+});
+
+const HorizontalDivider = styled.span(
+  {
+    height: '100%',
+    width: '1px',
+  },
+  ({ theme }) => ({ backgroundColor: theme.colors.gray2 }),
+);
+
+const EmptyButtonCss = css({
+  all: 'unset',
+  cursor: 'pointer',
+  width: '50%',
+  height: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+const Button = styled.button(
+  {
+    ...EmptyButtonCss,
+  },
+  ({ theme }) => ({ ...theme.typographies.button2, color: theme.colors.gray4 }),
+);
+
+const WarningButton = styled.button({ ...EmptyButtonCss }, ({ theme }) => ({
+  ...theme.typographies.button2,
+  color: theme.colors.danger,
+}));
+
+const ContentTitle = styled.span(({ theme }) => ({ ...theme.typographies.subTitle, color: theme.colors.gray6 }));
+
+const ContentBody = styled.span(({ theme }) => ({ ...theme.typographies.body1, color: theme.colors.gray4 }));
+
+Dialog.ContentTitle = ContentTitle;
+Dialog.ContentBody = ContentBody;
+Dialog.Button = Button;
+Dialog.WarningButton = WarningButton;
+
+export default Dialog;

--- a/src/components/portal/StyledMotionScrim.ts
+++ b/src/components/portal/StyledMotionScrim.ts
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+import { m } from 'framer-motion';
+
+const StyledMotionScrim = styled(m.div)`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 900;
+
+  width: 100vw;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+
+  overflow: hidden;
+`;
+
+export default StyledMotionScrim;

--- a/src/components/route-search/CategorySection.tsx
+++ b/src/components/route-search/CategorySection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Chip from '../chip/Chip';
 import styled from '@emotion/styled';
 
-function CategorySection() {
+import Chip from '../chip/Chip';
+
+const CategorySection = () => {
   return (
     <Wrapper>
       {CATEGORY_DUMMY.map((name) => (
@@ -10,7 +11,7 @@ function CategorySection() {
       ))}
     </Wrapper>
   );
-}
+};
 
 export default CategorySection;
 

--- a/src/components/route-search/ListRequestSection.tsx
+++ b/src/components/route-search/ListRequestSection.tsx
@@ -1,8 +1,9 @@
-import styled from '@emotion/styled';
 import React from 'react';
+import styled from '@emotion/styled';
+
 import Button from '../button/Button';
 
-function ListRequestSection() {
+const ListRequestSection = () => {
   return (
     <div>
       <MainTitle>찾으시는 리스트가 없나요?</MainTitle>
@@ -10,7 +11,7 @@ function ListRequestSection() {
       <Button>리스트 요청하기</Button>
     </div>
   );
-}
+};
 
 export default ListRequestSection;
 

--- a/src/constants/motions.ts
+++ b/src/constants/motions.ts
@@ -27,3 +27,24 @@ export const defaultFadeInVariants: Variants = {
     willChange: 'opacity',
   },
 };
+
+export const defaultFadeInUpVariants: Variants = {
+  initial: {
+    opacity: 0,
+    y: 30,
+    transition: { duration: 0.3, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.3, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+  exit: {
+    opacity: 0,
+    y: 30,
+    transition: { duration: 0.3, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+};

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -1,12 +1,13 @@
 import { ReactElement } from 'react';
 import styled from '@emotion/styled';
+
 import { NextPageWithLayout } from '../_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-search/CategorySection';
-import SearchCard from '@/components/route-search/SearchCard';
 import ListRequestSection from '@/components/route-search/ListRequestSection';
+import SearchCard from '@/components/route-search/SearchCard';
 import { mockCheckboxGroupOptions, mockCheckboxGroupTitle } from '@/fixtures/checkboxGroup.mock';
 
 const Template: NextPageWithLayout = () => {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

> `route-search/CategorySection`, `route-search/ListRequestSection`, `pages/template/index.page.tsx`는 이전에 머지된 부분에서 린트가 적용안된 파일이에요. 무시해 주세요!

closes #64 



## 🎉 어떻게 해결했나요?
- `defaultFadeInUpVariants`라는 이름으로 올라오고 내려가는 framer-motion variants를 정의했어요
- `BottomSheet`와 `Dialog`에서 사용되는 scrim을 분리했어요

- `Dialog`를 아래와 같은 방법으로 사용할 수 있게 개발했어요
```tsx
  <Dialog
      isShowing={isShowing}
      setToClose={close}
      content={
        <>
          <Dialog.ContentTitle>진짜 닫을거?</Dialog.ContentTitle>
          <Dialog.ContentBody>어쩌구 저쩌구</Dialog.ContentBody>
        </>
      }
      leftButton={<Dialog.Button onClick={close}>닫기</Dialog.Button>}
      rightButton={<Dialog.WarningButton onClick={close}>진짜 닫기</Dialog.WarningButton>}
  />
```
  - 지금까지 나온 디자인을 봤을 때는 content, button 영역에 텍스트만 들어가지만
  이후에는 아이콘이 들어가던가 할 수 있을 거 같아, ReactNode, ReactElement type으로 받을 수 있게 해 두었어요
    - 그리고 텍스트에 대한 스타일은 컴파운드 형식으로 제공했어요

  - `content` 부분을 `children`으로 받는 것이 이상적일 지 고민했으나,
  사용하는 곳에서 직관적으로 알 수 있는 방법은 현재 적용 방법이라 생각했어요.
    - 다른 의견 말씀해 주시면 감사드리겠습니다 !!

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 

https://user-images.githubusercontent.com/26461307/204070865-2d733f65-2c73-44bd-95bc-05827e9ed104.mov

