### PR TITLE
홈 추천 section 드래그 버튼 스타일 적용 및 드래그 로직 개선

### DIFF
--- a/src/components/route-home/RecommendSection.tsx
+++ b/src/components/route-home/RecommendSection.tsx
@@ -11,7 +11,7 @@ import useDidUpdate from '@/hooks/life-cycle/useDidUpdate';
 const HIDE_BOTTOM_POS = 84;
 
 const RecommendSection = () => {
-  const { onDragStart, onDragEnd, onMouseUp, onClickToggleButton, animationControls } = useSectionVisible();
+  const { onDragStart, onDragEnd, onClickToggleButton, animationControls } = useSectionVisible();
 
   // TODO: API 부착 이후 대응
   const testFn = () => {
@@ -29,7 +29,6 @@ const RecommendSection = () => {
         dragConstraints={{ top: 0, bottom: HIDE_BOTTOM_POS }}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
-        onMouseUp={onMouseUp}
       >
         <DragHandlerButton type="button" onClick={onClickToggleButton}>
           <DragHandlerSpan />
@@ -102,16 +101,24 @@ const useSectionVisible = () => {
   const [isVisible, setIsVisible, toggleVisible] = useToggle(true);
   const isDragRef = useRef<boolean>(false);
 
+  const startAnimationDependsOnIsVisble = () => {
+    if (isVisible) {
+      animationControls.start(visibleMotion);
+    } else {
+      animationControls.start(hideMotion);
+    }
+  };
+
   const onDragStart = () => {
     isDragRef.current = true;
   };
 
   const onDragEnd: DragHandlers['onDragEnd'] = (_, info) => {
     const shouldVisible = info.velocity.y < -50 && info.offset.y < 0;
-    setIsVisible(shouldVisible);
-  };
 
-  const onMouseUp = () => {
+    setIsVisible(shouldVisible);
+    startAnimationDependsOnIsVisble();
+
     setTimeout(() => {
       isDragRef.current = false;
     }, 0);
@@ -123,14 +130,10 @@ const useSectionVisible = () => {
   };
 
   useDidUpdate(() => {
-    if (isVisible) {
-      animationControls.start(visibleMotion);
-    } else {
-      animationControls.start(hideMotion);
-    }
+    startAnimationDependsOnIsVisble();
   }, [isVisible]);
 
-  return { onDragStart, onDragEnd, onMouseUp, onClickToggleButton, animationControls };
+  return { onDragStart, onDragEnd, onClickToggleButton, animationControls };
 };
 
 const visibleMotion = {

--- a/src/components/route-search/CategorySection.tsx
+++ b/src/components/route-search/CategorySection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Chip from '../chip/Chip';
 import styled from '@emotion/styled';
 
-function CategorySection() {
+import Chip from '../chip/Chip';
+
+const CategorySection = () => {
   return (
     <Wrapper>
       {CATEGORY_DUMMY.map((name) => (
@@ -10,7 +11,7 @@ function CategorySection() {
       ))}
     </Wrapper>
   );
-}
+};
 
 export default CategorySection;
 

--- a/src/components/route-search/ListRequestSection.tsx
+++ b/src/components/route-search/ListRequestSection.tsx
@@ -1,8 +1,9 @@
-import styled from '@emotion/styled';
 import React from 'react';
+import styled from '@emotion/styled';
+
 import Button from '../button/Button';
 
-function ListRequestSection() {
+const ListRequestSection = () => {
   return (
     <div>
       <MainTitle>찾으시는 리스트가 없나요?</MainTitle>
@@ -10,7 +11,7 @@ function ListRequestSection() {
       <Button>리스트 요청하기</Button>
     </div>
   );
-}
+};
 
 export default ListRequestSection;
 

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -1,12 +1,13 @@
 import { ReactElement } from 'react';
 import styled from '@emotion/styled';
+
 import { NextPageWithLayout } from '../_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-search/CategorySection';
-import SearchCard from '@/components/route-search/SearchCard';
 import ListRequestSection from '@/components/route-search/ListRequestSection';
+import SearchCard from '@/components/route-search/SearchCard';
 import { mockCheckboxGroupOptions, mockCheckboxGroupTitle } from '@/fixtures/checkboxGroup.mock';
 
 const Template: NextPageWithLayout = () => {


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
> `route-search/CategorySection`, `route-search/ListRequestSection`, `pages/template/index.page.tsx`는 이전에 머지된 부분에서 린트가 적용안된 파일이에요. 무시해 주세요!

closes #95 

+ 드래그 로직
  - 아래로 드래그가 시각적으로 적용이 안되고, 결과만 적용되었음
  - 드래그 로직과 버튼의 click 이벤트가 발생하는 경우가 있어서, 올리자마자 내려가는 경우 발생
  - 드래그 이후 동일한 상태일 때 애니메이션 적용이 안되고 위치가 고정됨

## 🎉 어떻게 해결했나요?

- 사용성을 위해 상단 영역 전체를 버튼으로 잡고, 자식에 디자인을 적용했어요

![스크린샷 2022-11-26 오후 8 39 18](https://user-images.githubusercontent.com/26461307/204086815-b4007ffa-4b8d-4555-aba3-21ff5dc78af3.png)

### 아래로 드래그가 안되는 문제

- `variants`로 적용되고 있던 높이에서 framer-motion의 `useAnimationControls`를 이용하는 방법으로 대응해 해결했어요

https://www.framer.com/docs/use-animation-controls/

### 드래그 로직과 버튼의 click 이벤트 발생

- `ref` 객체를 이용해 드래그 상태를 동기적으로 갱신, 확인해 `drag`와 `click` 이벤트를 막았어요

  - 드래그 이후 `setTimeout(, 0)`으로 드래그 상태를 갱신해, 이벤트 루프를 이용해 갱신되게 했어요
      `기존 : onDragStart => onDragEnd => Click` -> 
      `이후 : onDragStart => onDragEnd (큐에 넣) => Click => onDragEnd (실행)`

      > 사실 이렇게 하는게 옳을 지는 잘 모르겠어요 ..

### 드래그 이후 동일한 상태일 때 위치 고정

- 애니메이션 실행 함수를 분리하고, 드래그가 끝났을 때 실행하도록 하여 해결했어요

https://github.com/depromeet/ahmatda-web/blob/8c7e7e3fa32278131c6cf391d64000ebb2b0c5db/src/components/route-home/RecommendSection.tsx#L104-L125

### 이외

기존에 `shouldClose`, `isVIsible`, `show` 라는 이름으로 관리하던 변수명을, `shouldVisible`, `isVisible`, `visible`로 변경해 일관성을 높이고자 했어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 