### PR TITLE
홈 카테고리 섹션 마크업

### DIFF
--- a/src/components/route-home/CategorySection.tsx
+++ b/src/components/route-home/CategorySection.tsx
@@ -1,0 +1,60 @@
+import styled from '@emotion/styled';
+
+import IconButton from '../button/IconButton';
+import Chip from '../chip/Chip';
+import IconOverflow from '../icon/IconOverflow';
+
+const CategorySection = () => {
+  return (
+    <Section>
+      <ChipWrapper>
+        <Chip label="일상" color="black" />
+        <Chip label="일상" />
+        <Chip label="일상" />
+        <Chip label="일상" />
+      </ChipWrapper>
+
+      <OverflowWrapper>
+        <IconButton>
+          <IconOverflow />
+        </IconButton>
+      </OverflowWrapper>
+    </Section>
+  );
+};
+
+export default CategorySection;
+
+const Section = styled.section({
+  width: '100%',
+  height: '56px',
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: '8px',
+});
+
+const ChipWrapper = styled.div({
+  position: 'relative',
+  width: `calc(100% - 40px)`,
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
+  overflowX: 'auto',
+
+  '& > *': {
+    flexShrink: '0',
+  },
+});
+
+const OverflowWrapper = styled.div({ position: 'relative' }, ({ theme }) => ({
+  '&::after': {
+    content: '""',
+    position: 'absolute',
+    top: '0',
+    right: '100%',
+    width: '24px',
+    height: '100%',
+    background: `linear-gradient(to right, rgba(0, 0, 0, 0), ${theme.colors.gray1} 90%)`,
+  },
+}));

--- a/src/components/route-search/CategorySection.tsx
+++ b/src/components/route-search/CategorySection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Chip from '../chip/Chip';
 import styled from '@emotion/styled';
 
-function CategorySection() {
+import Chip from '../chip/Chip';
+
+const CategorySection = () => {
   return (
     <Wrapper>
       {CATEGORY_DUMMY.map((name) => (
@@ -10,7 +11,7 @@ function CategorySection() {
       ))}
     </Wrapper>
   );
-}
+};
 
 export default CategorySection;
 

--- a/src/components/route-search/ListRequestSection.tsx
+++ b/src/components/route-search/ListRequestSection.tsx
@@ -1,8 +1,9 @@
-import styled from '@emotion/styled';
 import React from 'react';
+import styled from '@emotion/styled';
+
 import Button from '../button/Button';
 
-function ListRequestSection() {
+const ListRequestSection = () => {
   return (
     <div>
       <MainTitle>찾으시는 리스트가 없나요?</MainTitle>
@@ -10,7 +11,7 @@ function ListRequestSection() {
       <Button>리스트 요청하기</Button>
     </div>
   );
-}
+};
 
 export default ListRequestSection;
 

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -4,10 +4,16 @@ import { NextPageWithLayout } from './_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
+import CategorySection from '@/components/route-home/CategorySection';
 import RecommendSection from '@/components/route-home/RecommendSection';
 
 const HomePage: NextPageWithLayout = () => {
-  return <RecommendSection />;
+  return (
+    <>
+      <CategorySection />
+      <RecommendSection />
+    </>
+  );
 };
 
 HomePage.getLayout = function getLayout(page: ReactElement) {

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -1,12 +1,13 @@
 import { ReactElement } from 'react';
 import styled from '@emotion/styled';
+
 import { NextPageWithLayout } from '../_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-search/CategorySection';
-import SearchCard from '@/components/route-search/SearchCard';
 import ListRequestSection from '@/components/route-search/ListRequestSection';
+import SearchCard from '@/components/route-search/SearchCard';
 import { mockCheckboxGroupOptions, mockCheckboxGroupTitle } from '@/fixtures/checkboxGroup.mock';
 
 const Template: NextPageWithLayout = () => {

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -26,7 +26,7 @@ export const setGlobalStyles = css`
 
   * {
     font-family: inherit;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     margin: 0;
     padding: 0;
 


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

> `route-search/CategorySection`, `route-search/ListRequestSection`, `pages/template/index.page.tsx`는 이전에 머지된 부분에서 린트가 적용안된 파일이에요. 무시해 주세요!

closes #56 

## 🎉 어떻게 해결했나요?
- `GlobalStyle`에 `box-sizing`에 `!important`를 사용했어요 ㅠ
  - 무슨 이유에선지 적용이 안되는 요소들이 있더라구요. 아마 `emotionNormalize`에서 우선순위가 높은 선택자로 되어 있지 않나 ... 싶긴해요

![스크린샷 2022-11-26 오후 9 37 44](https://user-images.githubusercontent.com/26461307/204089328-91879024-754a-422f-9232-e0c21e8f2f93.png)

- 카테고리 섹션의 마크업을 했어요
  - 가상 선택자를 이용해 그레디언트를 보여줬어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 