### PR TITLE
Carousel, Indicator 컴포넌트 리팩토링

### DIFF
--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, PropsWithChildren, Ref } from 'react';
 import styled from '@emotion/styled';
 
+import Indicator from './Indicator';
+
 const CarouselWrapper = forwardRef(function CarouselWrapper(
   { children }: PropsWithChildren,
   forwardedRef: Ref<HTMLDivElement>,
@@ -27,6 +29,6 @@ const Item = styled.article({
   width: '100%',
 });
 
-const Carousel = { Wrapper: CarouselWrapper, Item: CarouselItem };
+const Carousel = { Wrapper: CarouselWrapper, Item: CarouselItem, Indicator };
 
 export default Carousel;

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -29,6 +29,21 @@ const Item = styled.article({
   width: '100%',
 });
 
+/**
+ * Carousel에 필요한 컴포넌트들을 사용할 수 있어요
+ *
+ * @example
+ * ```tsx
+ * <Carousel.Wrapper ref={setCarouselWrapper}>
+    <Carousel.Item>
+      first
+    </Carousel.Item>
+    // ...
+  </Carousel.Wrapper>
+  <Carousel.Indicator carouselWrapper={carouselWrapper} />
+ * ```
+ *
+ */
 const Carousel = { Wrapper: CarouselWrapper, Item: CarouselItem, Indicator };
 
 export default Carousel;

--- a/src/components/carousel/Indicator.tsx
+++ b/src/components/carousel/Indicator.tsx
@@ -4,13 +4,16 @@ import throttle from 'lodash/throttle';
 
 interface Props {
   /**
+   * # 이 컴포넌트는 단독으로 사용하지 못해요
+   * `Carousel`의 자식으로써 사용하는 것을 권장해요
+   *
    * @example
    * ```tsx
    * const [wrapper, setWrapper] = useState<HTMLDivElement | null>(null);
    *
    * <Carousel.Wrapper ref={setWrapper}>
    * </Carousel.Wrapper>
-   * <Indicator carouselWrapper={wrapper} />
+   * <Carousel.Indicator carouselWrapper={wrapper} />
    * ```
    */
   carouselWrapper: HTMLDivElement | null;

--- a/src/components/route-search/CategorySection.tsx
+++ b/src/components/route-search/CategorySection.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import Chip from '../chip/Chip';
 import styled from '@emotion/styled';
 
-function CategorySection() {
+import Chip from '../chip/Chip';
+
+const CategorySection = () => {
   return (
     <Wrapper>
       {CATEGORY_DUMMY.map((name) => (
@@ -10,7 +11,7 @@ function CategorySection() {
       ))}
     </Wrapper>
   );
-}
+};
 
 export default CategorySection;
 

--- a/src/components/route-search/ListRequestSection.tsx
+++ b/src/components/route-search/ListRequestSection.tsx
@@ -1,8 +1,9 @@
-import styled from '@emotion/styled';
 import React from 'react';
+import styled from '@emotion/styled';
+
 import Button from '../button/Button';
 
-function ListRequestSection() {
+const ListRequestSection = () => {
   return (
     <div>
       <MainTitle>찾으시는 리스트가 없나요?</MainTitle>
@@ -10,7 +11,7 @@ function ListRequestSection() {
       <Button>리스트 요청하기</Button>
     </div>
   );
-}
+};
 
 export default ListRequestSection;
 

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -1,12 +1,13 @@
 import { ReactElement } from 'react';
 import styled from '@emotion/styled';
+
 import { NextPageWithLayout } from '../_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-search/CategorySection';
-import SearchCard from '@/components/route-search/SearchCard';
 import ListRequestSection from '@/components/route-search/ListRequestSection';
+import SearchCard from '@/components/route-search/SearchCard';
 import { mockCheckboxGroupOptions, mockCheckboxGroupTitle } from '@/fixtures/checkboxGroup.mock';
 
 const Template: NextPageWithLayout = () => {

--- a/src/pages/test/index.page.tsx
+++ b/src/pages/test/index.page.tsx
@@ -7,7 +7,6 @@ import ContainedButton from '@/components/button/ContainedButton';
 import IconButton from '@/components/button/IconButton';
 import LabelButton from '@/components/button/LabelButton';
 import Carousel from '@/components/carousel/Carousel';
-import Indicator from '@/components/carousel/Indicator';
 import Checkbox from '@/components/checkbox/Checkbox';
 import CheckboxWithText from '@/components/checkbox/CheckboxWithText';
 import Chip from '@/components/chip/Chip';
@@ -141,7 +140,7 @@ const Test = () => {
             <TestDiv>c</TestDiv>
           </Carousel.Item>
         </Carousel.Wrapper>
-        <Indicator carouselWrapper={carouselWrapper} />
+        <Carousel.Indicator carouselWrapper={carouselWrapper} />
       </div>
 
       <div>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

> `route-search/CategorySection`, `route-search/ListRequestSection`, `pages/template/index.page.tsx`는 이전에 머지된 부분에서 린트가 적용안된 파일이에요. 무시해 주세요!

closes #70 

- 개발자가 `Carousel`과 `Indicator`가 짝이라는 것을 인지하고 있어야함

## 🎉 어떻게 해결했나요?

- `Carousel` obj에 `Indicator`를 추가했어요
  - 관련해 jsdoc도 작성해 봤어요

민규님이 말씀해 주신 대로 아래처럼 해볼까 했으나,
```tsx
const Carousel = () => {
 return ...
}

Carousel.Wrapper = Wrapper; // 얘를 Carousel 로?
Carousel.Item = Item;
```

이렇게 되면 `Carousel`이라는 컴포넌트가 `Wrapper`를 맡거나, Fragment 정도? 반환하는 형태가 될 것 같았어요

```tsx
<Carousel>
  <Carousel.Item />
</Carousel>
```

그래서 지금 형태를 유지하면서 `Indicator`만 추가하는 식으로 대응했어요

```tsx
<Carousel.Wrapper>
  <Carousel.Item />
</Carousel.Wrapper>
```

지금 방식이 더 가독성이나 사용성이 낮다고 생각하신다면 편하게 말씀해주세요 !! 


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 