### PR TITLE
Home 카테고리 설정 Bottom sheet 마크업

### DIFF
--- a/src/components/button/LabelButton.tsx
+++ b/src/components/button/LabelButton.tsx
@@ -30,6 +30,8 @@ const StyledLabelButton = styled(Button)<StyledLabelButtonProps>`
   padding: 8px;
   background-color: inherit;
   color: ${({ theme }) => theme.colors.gray3};
+  display: flex;
+  align-items: center;
 
   &:active {
     background-color: inherit;

--- a/src/components/navigation/AppBar.tsx
+++ b/src/components/navigation/AppBar.tsx
@@ -47,12 +47,15 @@ const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
 
 export default AppBar;
 
+const APP_BAR_HEIGHT = '48px';
+
 const Wrapper = styled.section(
   {
     position: 'sticky',
+    left: 0,
     top: '0',
     width: '100%',
-    height: '48px',
+    height: APP_BAR_HEIGHT,
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
@@ -82,5 +85,40 @@ const Title = styled.h2(
   },
   ({ theme }) => ({
     ...theme.typographies.subTitle,
+    color: theme.colors.gray6,
   }),
 );
+
+export const BottomSheetAppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
+  const router = useRouter();
+
+  const handleBackButton = () => {
+    if (onClickBackButton) {
+      onClickBackButton();
+      return;
+    }
+    router.back();
+  };
+
+  return (
+    <>
+      <BottomSheetWrapper>
+        <BackButton onClick={handleBackButton}>
+          <IconChevron24pxRightLeft direction="left" />
+        </BackButton>
+        {title && <Title>{title}</Title>}
+        {rightElement && rightElement}
+      </BottomSheetWrapper>
+      <ScrollableDiv />
+    </>
+  );
+};
+
+const BottomSheetWrapper = styled(Wrapper)({
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  marginTop: '16px',
+});
+
+const ScrollableDiv = styled.div({ height: APP_BAR_HEIGHT });

--- a/src/components/navigation/AppBar.tsx
+++ b/src/components/navigation/AppBar.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactElement } from 'react';
 import { useRouter } from 'next/router';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import IconChevron24pxRightLeft from '../icon/IconChevron24pxRightLeft';
@@ -21,9 +22,15 @@ interface Props {
    * 값을 주입하지 않을 시 `router.back()`이 실행됩니다
    */
   onClickBackButton?: VoidFunction;
+  /**
+   * `BottomSheet`등에서 layout에 구애받지 않고 사용될 때 사용합니다
+   *
+   * `position`이 `absolute`가 되며, `ScrollableDiv`를 렌더링합니다
+   */
+  isAbsolute?: boolean;
 }
 
-const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
+const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton, isAbsolute = false }) => {
   const router = useRouter();
 
   const handleBackButton = () => {
@@ -35,13 +42,16 @@ const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
   };
 
   return (
-    <Wrapper>
-      <BackButton onClick={handleBackButton}>
-        <IconChevron24pxRightLeft direction="left" />
-      </BackButton>
-      {title && <Title>{title}</Title>}
-      {rightElement && rightElement}
-    </Wrapper>
+    <>
+      <Wrapper isAbsolute={isAbsolute}>
+        <BackButton onClick={handleBackButton}>
+          <IconChevron24pxRightLeft direction="left" />
+        </BackButton>
+        {title && <Title>{title}</Title>}
+        {rightElement && rightElement}
+      </Wrapper>
+      {isAbsolute && <ScrollableDiv />}
+    </>
   );
 };
 
@@ -49,7 +59,7 @@ export default AppBar;
 
 const APP_BAR_HEIGHT = '48px';
 
-const Wrapper = styled.section(
+const Wrapper = styled.section<{ isAbsolute: boolean }>(
   {
     position: 'sticky',
     left: 0,
@@ -63,7 +73,15 @@ const Wrapper = styled.section(
     zIndex: '900',
   },
   ({ theme }) => ({ backgroundColor: theme.colors.white }),
+  ({ isAbsolute }) => isAbsolute && AbsoluteCss,
 );
+
+const AbsoluteCss = css({
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  marginTop: '16px',
+});
 
 const BackButton = styled.button({
   all: 'unset',
@@ -88,37 +106,5 @@ const Title = styled.h2(
     color: theme.colors.gray6,
   }),
 );
-
-export const BottomSheetAppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
-  const router = useRouter();
-
-  const handleBackButton = () => {
-    if (onClickBackButton) {
-      onClickBackButton();
-      return;
-    }
-    router.back();
-  };
-
-  return (
-    <>
-      <BottomSheetWrapper>
-        <BackButton onClick={handleBackButton}>
-          <IconChevron24pxRightLeft direction="left" />
-        </BackButton>
-        {title && <Title>{title}</Title>}
-        {rightElement && rightElement}
-      </BottomSheetWrapper>
-      <ScrollableDiv />
-    </>
-  );
-};
-
-const BottomSheetWrapper = styled(Wrapper)({
-  position: 'absolute',
-  top: '0',
-  left: '0',
-  marginTop: '16px',
-});
 
 const ScrollableDiv = styled.div({ height: APP_BAR_HEIGHT });

--- a/src/components/portal/BottomSheet.tsx
+++ b/src/components/portal/BottomSheet.tsx
@@ -42,14 +42,13 @@ const StyledMotionContent = styled(m.div)`
   top: 100%;
   width: 100%;
   min-height: 420px;
-
+  max-height: 95%;
   padding-top: 16px;
   padding-left: 20px;
   padding-right: 20px;
-
   background-color: ${({ theme }) => theme.colors.white};
-
   border-radius: 20px 20px 0 0;
+  overflow: hidden;
   z-index: 1000;
 `;
 

--- a/src/components/route-home/CategorySection.tsx
+++ b/src/components/route-home/CategorySection.tsx
@@ -4,22 +4,35 @@ import IconButton from '../button/IconButton';
 import Chip from '../chip/Chip';
 import IconOverflow from '../icon/IconOverflow';
 
-const CategorySection = () => {
-  return (
-    <Section>
-      <ChipWrapper>
-        <Chip label="일상" color="black" />
-        <Chip label="일상" />
-        <Chip label="일상" />
-        <Chip label="일상" />
-      </ChipWrapper>
+import CategorySettingBottomSheet from './CategorySettingBottomSheet';
 
-      <OverflowWrapper>
-        <IconButton>
-          <IconOverflow />
-        </IconButton>
-      </OverflowWrapper>
-    </Section>
+import useToggle from '@/hooks/common/useToggle';
+
+const CategorySection = () => {
+  const [isCategorySettingShowing, setCategorySettingShowing, toggleCategorySettingShowing] = useToggle(false);
+
+  return (
+    <>
+      <Section>
+        <ChipWrapper>
+          <Chip label="일상" color="black" />
+          <Chip label="일상" />
+          <Chip label="일상" />
+          <Chip label="일상" />
+        </ChipWrapper>
+
+        <OverflowWrapper>
+          <IconButton onClick={toggleCategorySettingShowing}>
+            <IconOverflow />
+          </IconButton>
+        </OverflowWrapper>
+      </Section>
+
+      <CategorySettingBottomSheet
+        isShowing={isCategorySettingShowing}
+        setToClose={() => setCategorySettingShowing(false)}
+      />
+    </>
   );
 };
 

--- a/src/components/route-home/CategorySection.tsx
+++ b/src/components/route-home/CategorySection.tsx
@@ -1,12 +1,13 @@
+import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
 
 import IconButton from '../button/IconButton';
 import Chip from '../chip/Chip';
 import IconOverflow from '../icon/IconOverflow';
 
-import CategorySettingBottomSheet from './CategorySettingBottomSheet';
-
 import useToggle from '@/hooks/common/useToggle';
+
+const CategorySettingBottomSheet = dynamic(() => import('./CategorySettingBottomSheet'));
 
 const CategorySection = () => {
   const [isCategorySettingShowing, setCategorySettingShowing, toggleCategorySettingShowing] = useToggle(false);

--- a/src/components/route-home/CategorySettingBottomSheet.tsx
+++ b/src/components/route-home/CategorySettingBottomSheet.tsx
@@ -1,0 +1,18 @@
+import { ComponentProps } from 'react';
+
+import { BottomSheetAppBar } from '../navigation/AppBar';
+import BottomSheet from '../portal/BottomSheet';
+
+type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
+
+const CategorySettingBottomSheet = ({ isShowing, setToClose }: Props) => {
+  return (
+    <BottomSheet isShowing={isShowing} setToClose={setToClose}>
+      <BottomSheetAppBar title="카테고리 설정" onClickBackButton={setToClose} />
+
+      <h1> asdf asdf</h1>
+    </BottomSheet>
+  );
+};
+
+export default CategorySettingBottomSheet;

--- a/src/components/route-home/CategorySettingBottomSheet.tsx
+++ b/src/components/route-home/CategorySettingBottomSheet.tsx
@@ -1,18 +1,88 @@
-import { ComponentProps } from 'react';
+import { ComponentProps, FC, ReactElement } from 'react';
+import styled from '@emotion/styled';
 
-import { BottomSheetAppBar } from '../navigation/AppBar';
+import LabelButton from '../button/LabelButton';
+import IconAdd from '../icon/IconAdd';
+import IconChevron24pxRightLeft from '../icon/IconChevron24pxRightLeft';
+import AppBar from '../navigation/AppBar';
 import BottomSheet from '../portal/BottomSheet';
 
 type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
 
-const CategorySettingBottomSheet = ({ isShowing, setToClose }: Props) => {
+const CategorySettingBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
+  const testFn = () => {
+    // TODO: 이후 대응
+    // eslint-disable-next-line no-console
+    console.log('d');
+  };
+
   return (
     <BottomSheet isShowing={isShowing} setToClose={setToClose}>
-      <BottomSheetAppBar title="카테고리 설정" onClickBackButton={setToClose} />
+      <Wrapper>
+        <AppBar title="카테고리 설정" onClickBackButton={setToClose} isAbsolute />
 
-      <h1> asdf asdf</h1>
+        <CategoryItem icon={<IconAdd />} label="일상" onClick={testFn} />
+        <CategoryItem icon={<IconAdd />} label="여행" onClick={testFn} />
+
+        <PadlessLabelButton size="large">
+          <IconAdd />
+          추가하기
+        </PadlessLabelButton>
+      </Wrapper>
     </BottomSheet>
   );
 };
 
+const Wrapper = styled.div({
+  // NOTE: BottomSheet maxHeight에서 잘리는 것을 의도
+  height: '100vh',
+});
+
+const PadlessLabelButton = styled(LabelButton)({
+  marginTop: '8px',
+  paddingLeft: '0',
+});
+
 export default CategorySettingBottomSheet;
+
+interface CategoryItemProps {
+  icon: ReactElement;
+  label: string;
+  onClick: VoidFunction;
+}
+
+const CategoryItem: FC<CategoryItemProps> = ({ icon, label, onClick }) => {
+  return (
+    <WrapperButton type="button" onClick={onClick}>
+      <LeftWrapper>
+        {icon}
+        <span>{label}</span>
+      </LeftWrapper>
+      <IconChevron24pxRightLeft direction="right" />
+    </WrapperButton>
+  );
+};
+
+const WrapperButton = styled.button(
+  {
+    all: 'unset',
+    cursor: 'pointer',
+    width: '100%',
+    height: '48px',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  ({ theme }) => ({
+    ...theme.typographies.button2,
+    color: theme.colors.gray6,
+    borderBottom: `1px solid ${theme.colors.gray2}`,
+  }),
+);
+
+const LeftWrapper = styled.div({
+  height: '100%',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

closes #57

![스크린샷 2022-11-27 오후 3 50 54](https://user-images.githubusercontent.com/26461307/204123063-e20fde31-b043-46f9-a18c-5c27a1e4c7a4.png)


## 🎉 어떻게 해결했나요?

- `BottomSheet` 환경에서는 `AppBar`가 레이아웃 밖에 있어야 하는 환경이더라구요.  
  그래서 `AppBar`에 `isAbsolute` props를 추가해 대응했어요
  > 처음에는 컴포넌트를 분리했었는데 중복되는 로직이 많아 한 컴포넌트에서 대응하도록 했어요

- `BottomSheet`에 `overflow`, `maxHeight` 등 몇 스타일을 추가했어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 
- 이후 설정, 추가 플로우 마크업을 해 볼게요