### PR TITLE
notice route 마크업 및 흰색 배경 GlobalStyle 생성

### DIFF
--- a/src/components/navigation/DefaultAppBar.tsx
+++ b/src/components/navigation/DefaultAppBar.tsx
@@ -1,3 +1,4 @@
+import NextLink from 'next/link';
 import styled from '@emotion/styled';
 
 import IconAlarm from '../icon/IconAlarm';
@@ -7,9 +8,9 @@ const DefaultAppBar = () => {
   return (
     <Wrapper>
       <ButtonWrapper>
-        <Button>
+        <StyledLink href="/notice">
           <IconAlarm />
-        </Button>
+        </StyledLink>
 
         <Button>
           <IconMenu />
@@ -40,6 +41,7 @@ const ButtonWrapper = styled.div({
   top: '0',
   right: '-12px',
   height: '100%',
+  display: 'flex',
 });
 
 const Button = styled.button({
@@ -48,4 +50,12 @@ const Button = styled.button({
   width: '48px',
   height: '48px',
   textAlign: 'center',
+});
+
+const StyledLink = styled(NextLink)({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '48px',
+  height: '48px',
 });

--- a/src/components/route-notice/NoticeItem.tsx
+++ b/src/components/route-notice/NoticeItem.tsx
@@ -1,0 +1,33 @@
+import { FC, ReactNode } from 'react';
+import styled from '@emotion/styled';
+
+interface Props {
+  icon: ReactNode;
+  title: string;
+  // TODO: API 스펙에 따라 이름 변경 > 시간 계산 해당 컴포넌트에서 진행
+  time: string;
+}
+
+const NoticeItem: FC<Props> = ({ icon, title, time }) => {
+  return (
+    <Article>
+      {icon}
+      <TextWrapper>
+        <Heading>{title}</Heading>
+        <Span>{time}</Span>
+      </TextWrapper>
+    </Article>
+  );
+};
+
+export default NoticeItem;
+
+const Article = styled.article({ padding: '20px 0', display: 'flex', gap: '8px' }, ({ theme }) => ({
+  ...theme.typographies.body1,
+}));
+
+const TextWrapper = styled.div({ display: 'flex', flexDirection: 'column', gap: '8px' });
+
+const Heading = styled.h3(({ theme }) => ({ ...theme.typographies.body1 }));
+
+const Span = styled.span(({ theme }) => ({ ...theme.typographies.caption2, color: theme.colors.gray4 }));

--- a/src/pages/notice/index.page.tsx
+++ b/src/pages/notice/index.page.tsx
@@ -8,6 +8,7 @@ const Notice = () => {
   return (
     <>
       <WhiteBackgroundGlobalStyles />
+      {/* TODO: #106 이후 패딩 대응 */}
       <AppBar title="알림" />
       <Main>
         <NoticeItem icon="&#127911;" title="아맞다! 이어폰은 꼭 챙기셔야 해요!" time="1초 전" />

--- a/src/pages/notice/index.page.tsx
+++ b/src/pages/notice/index.page.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+
+import AppBar from '@/components/navigation/AppBar';
+import NoticeItem from '@/components/route-notice/NoticeItem';
+import { WhiteBackgroundGlobalStyles } from '@/styles/GlobalStyles';
+
+const Notice = () => {
+  return (
+    <>
+      <WhiteBackgroundGlobalStyles />
+      <AppBar title="알림" />
+      <Main>
+        <NoticeItem icon="&#127911;" title="아맞다! 이어폰은 꼭 챙기셔야 해요!" time="1초 전" />
+        <NoticeItem
+          icon="&#127911;"
+          title="이어폰, 노트북, 충전기, 보조배터리, 시계, 안경 모두 챙기셨나요? "
+          time="1초 전"
+        />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+        <NoticeItem icon="&#127911;" title="asdf" time="1초 전" />
+      </Main>
+    </>
+  );
+};
+
+export default Notice;
+
+const Main = styled.main({ paddingTop: '8px' });

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -29,6 +29,8 @@ export const setGlobalStyles = css`
     box-sizing: border-box !important;
     margin: 0;
     padding: 0;
+    word-break: keep-all;
+    word-wrap: break-word;
 
     -ms-overflow-style: none;
     scrollbar-width: none;

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -46,3 +46,16 @@ const GlobalStyles = (): ReactElement => {
 };
 
 export default GlobalStyles;
+
+const whiteBackgroundCss = css`
+  body {
+    background-color: ${theme.colors.white};
+  }
+`;
+
+/**
+ * 배경색이 흰색인 route에서 사용되는 GlobalStyles 입니다
+ */
+export const WhiteBackgroundGlobalStyles = () => {
+  return <Global styles={whiteBackgroundCss} />;
+};


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
closes #100



## 🎉 어떻게 해결했나요?

<img width="402" alt="스크린샷 2022-11-28 오전 11 46 23" src="https://user-images.githubusercontent.com/26461307/204180673-76dd7f6f-0af4-4b61-b5d5-23c81ccebd0d.png">

- 흰색 배경인 route에서 사용될 override용 `WhiteBackgroundGlobalStyles`를 생성했어요

- text-wrap, text-break 속성을 적용했어요
  https://wit.nts-corp.com/2017/07/25/4675

- `/notice` route를 만들고, 마크업 했어요
  - `NoticeItem`의 interface는 API interface를 확인 후 변경할 예정이에요
  - `AppBar`의 패딩은 #106 이후 대응할게요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 