### PR TITLE
useInput hook 개발

### DIFF
--- a/@types/common.d.ts
+++ b/@types/common.d.ts
@@ -1,0 +1,1 @@
+type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };

--- a/src/hooks/common/useInput.ts
+++ b/src/hooks/common/useInput.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent, Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 
 interface DebounceOption {
   useDebounce?: boolean;

--- a/src/hooks/common/useInput.ts
+++ b/src/hooks/common/useInput.ts
@@ -2,16 +2,41 @@ import { ChangeEvent, Dispatch, SetStateAction, useCallback, useMemo, useState }
 import debounce from 'lodash/debounce';
 
 interface DebounceOption {
+  /**
+   * debounce를 사용할 것인지 정의해요
+   *
+   * @default false
+   */
   useDebounce?: boolean;
+  /**
+   * debounce가 갱신될 ms 단위 시간이에요
+   *
+   * @default 150
+   */
   debounceTimeout?: number;
 }
 
 interface PropsWhenString extends DebounceOption {
+  /**
+   * value, debouncedValue의 초기값이에요
+   */
   initialValue: string;
 }
 
 interface PropsWhenGeneric<T> extends DebounceOption {
+  /**
+   * value, debouncedValue의 초기값이에요
+   */
   initialValue: T;
+  /**
+   * onChange의 value의 타입을 변환해 setStating할 parser에요
+   *
+   * @example
+   * ```tsx
+   * const { value, onChange } = useInput({ initialValue: 1, parser: Number });
+   * ```
+   *
+   */
   parser?: (value: string) => T;
 }
 
@@ -20,7 +45,20 @@ type Props<T> = PropsWhenString & PropsWhenGeneric<T>;
 interface Return<T> {
   value: T;
   setValue: Dispatch<SetStateAction<T>>;
+  /**
+   * debounce에 의해 갱신된 value에요
+   *
+   * `useDebounce`가 `true`로 설정되어 있어야 갱신돼요
+   */
   debouncedValue: T;
+  /**
+   * input의 onChange 핸들러에요
+   *
+   * @example
+   * ```tsx
+   * <input value={value} onChange={onChange} />
+   * ```
+   */
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
 }
 

--- a/src/hooks/common/useInput.ts
+++ b/src/hooks/common/useInput.ts
@@ -1,0 +1,93 @@
+import { ChangeEvent, Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
+import { debounce } from 'lodash';
+
+interface DebounceOption {
+  useDebounce?: boolean;
+  debounceTimeout?: number;
+}
+
+interface PropsWhenString extends DebounceOption {
+  initialValue: string;
+}
+
+interface PropsWhenGeneric<T> extends DebounceOption {
+  initialValue: T;
+  parser?: (value: string) => T;
+}
+
+type Props<T> = PropsWhenString & PropsWhenGeneric<T>;
+
+interface Return<T> {
+  value: T;
+  setValue: Dispatch<SetStateAction<T>>;
+  debouncedValue: T;
+  onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
+}
+
+function useInput({ initialValue, useDebounce, debounceTimeout }: PropsWhenString): Return<string>;
+
+function useInput<T>({ initialValue, useDebounce, debounceTimeout, parser }: PropsWhenGeneric<T>): Return<T>;
+
+function useInput<T>({ initialValue, useDebounce = false, debounceTimeout = 150, parser }: Props<T>) {
+  const [value, setValue] = useState<string | T>(initialValue);
+  const [debouncedValue, setDebouncedValue] = useState<string | T>(initialValue);
+
+  const handleDebounceValue = useMemo(
+    () =>
+      debounce((changedValue: string | T) => {
+        setDebouncedValue(changedValue);
+      }, debounceTimeout),
+    [],
+  );
+
+  const handleChangedValue = useCallback((changedValue: string | T) => {
+    setValue(changedValue);
+    if (useDebounce) handleDebounceValue(changedValue);
+  }, []);
+
+  const onChange = useCallback((e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => {
+    if (parser) {
+      handleChangedValue(parser(e.target.value));
+      return;
+    }
+
+    handleChangedValue(e.target.value);
+  }, []);
+
+  return { value, setValue, debouncedValue, onChange };
+}
+// const useInput = <T>({
+//   initialValue,
+//   useDebounce = false,
+//   debounceTimeout = 150,
+//   parser,
+// }: PropsWhenString & PropsWhenGeneric<T>) => {
+//   const [value, setValue] = useState<string | T>(initialValue);
+//   const [debouncedValue, setDebouncedValue] = useState<string | T>(initialValue);
+
+//   const handleDebounceValue = useMemo(
+//     () =>
+//       debounce((changedValue: string | T) => {
+//         setDebouncedValue(changedValue);
+//       }, debounceTimeout),
+//     [],
+//   );
+
+//   const handleChangedValue = useCallback((changedValue: string | T) => {
+//     setValue(changedValue);
+//     if (useDebounce) handleDebounceValue(changedValue);
+//   }, []);
+
+//   const onChange = useCallback((e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => {
+//     if (parser) {
+//       handleChangedValue(parser(e.target.value));
+//       return;
+//     }
+
+//     handleChangedValue(e.target.value);
+//   }, []);
+
+//   return { value, setValue, debouncedValue, onChange };
+// };
+
+export default useInput;

--- a/src/hooks/common/useInput.ts
+++ b/src/hooks/common/useInput.ts
@@ -1,7 +1,11 @@
 import { ChangeEvent, Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react';
 import debounce from 'lodash/debounce';
 
-interface DebounceOption {
+interface Props<T> {
+  /**
+   * value, debouncedValue의 초기값이에요
+   */
+  initialValue: T;
   /**
    * debounce를 사용할 것인지 정의해요
    *
@@ -14,22 +18,10 @@ interface DebounceOption {
    * @default 150
    */
   debounceTimeout?: number;
-}
-
-interface PropsWhenString extends DebounceOption {
-  /**
-   * value, debouncedValue의 초기값이에요
-   */
-  initialValue: string;
-}
-
-interface PropsWhenGeneric<T> extends DebounceOption {
-  /**
-   * value, debouncedValue의 초기값이에요
-   */
-  initialValue: T;
   /**
    * onChange의 value의 타입을 변환해 setStating할 parser에요
+   *
+   * type이 string이 아닐 시 `required` 해요
    *
    * @example
    * ```tsx
@@ -40,45 +32,37 @@ interface PropsWhenGeneric<T> extends DebounceOption {
   parser?: (value: string) => T;
 }
 
-type Props<T> = PropsWhenString & PropsWhenGeneric<T>;
+type PropsWhenNotString<T> = WithRequired<Props<T>, 'parser'>;
 
 interface Return<T> {
   value: T;
   setValue: Dispatch<SetStateAction<T>>;
-  /**
-   * debounce에 의해 갱신된 value에요
-   *
-   * `useDebounce`가 `true`로 설정되어 있어야 갱신돼요
-   */
   debouncedValue: T;
-  /**
-   * input의 onChange 핸들러에요
-   *
-   * @example
-   * ```tsx
-   * <input value={value} onChange={onChange} />
-   * ```
-   */
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
-function useInput({ initialValue, useDebounce, debounceTimeout }: PropsWhenString): Return<string>;
+function useInput({ initialValue, useDebounce, debounceTimeout, parser }: Props<string>): Return<string>;
 
-function useInput<T>({ initialValue, useDebounce, debounceTimeout, parser }: PropsWhenGeneric<T>): Return<T>;
+function useInput<T>({ initialValue, useDebounce, debounceTimeout, parser }: PropsWhenNotString<T>): Return<T>;
 
-function useInput<T>({ initialValue, useDebounce = false, debounceTimeout = 150, parser }: Props<T>) {
-  const [value, setValue] = useState<string | T>(initialValue);
-  const [debouncedValue, setDebouncedValue] = useState<string | T>(initialValue);
+function useInput<T extends string | number | boolean>({
+  initialValue,
+  useDebounce = false,
+  debounceTimeout = 150,
+  parser,
+}: Props<T>) {
+  const [value, setValue] = useState<T>(initialValue);
+  const [debouncedValue, setDebouncedValue] = useState<T>(initialValue);
 
   const handleDebounceValue = useMemo(
     () =>
-      debounce((changedValue: string | T) => {
+      debounce((changedValue: T) => {
         setDebouncedValue(changedValue);
       }, debounceTimeout),
     [],
   );
 
-  const handleChangedValue = useCallback((changedValue: string | T) => {
+  const handleChangedValue = useCallback((changedValue: T) => {
     setValue(changedValue);
     if (useDebounce) handleDebounceValue(changedValue);
   }, []);
@@ -89,43 +73,10 @@ function useInput<T>({ initialValue, useDebounce = false, debounceTimeout = 150,
       return;
     }
 
-    handleChangedValue(e.target.value);
+    handleChangedValue(e.target.value as T);
   }, []);
 
   return { value, setValue, debouncedValue, onChange };
 }
-// const useInput = <T>({
-//   initialValue,
-//   useDebounce = false,
-//   debounceTimeout = 150,
-//   parser,
-// }: PropsWhenString & PropsWhenGeneric<T>) => {
-//   const [value, setValue] = useState<string | T>(initialValue);
-//   const [debouncedValue, setDebouncedValue] = useState<string | T>(initialValue);
-
-//   const handleDebounceValue = useMemo(
-//     () =>
-//       debounce((changedValue: string | T) => {
-//         setDebouncedValue(changedValue);
-//       }, debounceTimeout),
-//     [],
-//   );
-
-//   const handleChangedValue = useCallback((changedValue: string | T) => {
-//     setValue(changedValue);
-//     if (useDebounce) handleDebounceValue(changedValue);
-//   }, []);
-
-//   const onChange = useCallback((e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => {
-//     if (parser) {
-//       handleChangedValue(parser(e.target.value));
-//       return;
-//     }
-
-//     handleChangedValue(e.target.value);
-//   }, []);
-
-//   return { value, setValue, debouncedValue, onChange };
-// };
 
 export default useInput;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
closes #89

- 다양한 input에 대응하는 상태와 onChange 핸들러를 반복적으로 작성해야 함

## 🎉 어떻게 해결했나요?
- `useInput` 이라는 이름으로 `state`, `setState`, `onChange`, `debouncedValue`를 반환하도록 개발했어요

## 사용 방법

### plain

```tsx
const { value, setValue, onChange } = useInput({ initialValue: ''});
```

### debounce

```tsx
const { value, debouncedValue, onChange } = useInput({ initialValue: '', useDebounce: true, debounceTimeout: 200 });
``` 

`useDebounce`는 optional로 기본 `false`에요

`debouncedTimeout`도 optional로 기본 `150`이에요

### with parser

```tsx
const { value, onChange } = useInput({ initialValue: 1, parser: Number });

// const { value, onChange } = useInput<number>({ initialValue: 1, parser: Number });
```

![스크린샷 2022-11-28 오후 8 48 23](https://user-images.githubusercontent.com/26461307/204270488-fcfbfbb3-2285-4226-ac7b-431f68963fdb.png)

> 타입 추론 예시

![스크린샷 2022-11-28 오후 8 49 10](https://user-images.githubusercontent.com/26461307/204270648-d4464c25-7483-48d0-9539-dc4e9a18df4d.png)

> 잘못된 parser 사용 예시

common하게 쓰일 수 있도록 `parser`를 주입할 수 있도록 했어요

> `parser?: (value: string) => T`


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 