### PR TITLE
Home 카테고리 추가 bottom sheet

### DIFF
--- a/src/components/button/LabelButton.tsx
+++ b/src/components/button/LabelButton.tsx
@@ -29,7 +29,7 @@ type StyledLabelButtonProps = Required<Pick<Props, 'size'>>;
 const StyledLabelButton = styled(Button)<StyledLabelButtonProps>`
   padding: 8px;
   background-color: inherit;
-  color: ${({ theme }) => theme.colors.gray3};
+  color: ${({ theme }) => theme.colors.gray5};
   display: flex;
   align-items: center;
 
@@ -39,7 +39,7 @@ const StyledLabelButton = styled(Button)<StyledLabelButtonProps>`
 
   &:disabled {
     background-color: inherit;
-    color: ${({ theme }) => theme.colors.gray5};
+    color: ${({ theme }) => theme.colors.gray3};
   }
 
   ${({ size }) => size === 'small' && smallCss}

--- a/src/components/route-home/CategoryAppendBottomSheet.tsx
+++ b/src/components/route-home/CategoryAppendBottomSheet.tsx
@@ -101,7 +101,6 @@ const RadioItem: FC<RadioItemProps> = ({ value, ...rest }) => {
 const HidedInput = styled.input(
   {
     position: 'absolute',
-    appearance: 'none',
     clipPath: 'polygon(0 0, 0 0, 0 0)',
   },
   ({ theme }) => ({

--- a/src/components/route-home/CategoryAppendBottomSheet.tsx
+++ b/src/components/route-home/CategoryAppendBottomSheet.tsx
@@ -1,0 +1,131 @@
+import { ComponentProps, FC, InputHTMLAttributes, MouseEvent, useId, useState } from 'react';
+import styled from '@emotion/styled';
+
+import LabelButton from '../button/LabelButton';
+import AppBar from '../navigation/AppBar';
+import BottomSheet from '../portal/BottomSheet';
+import TextField from '../text-field/TextField';
+
+import IconRadioGroup from './IconRadioGroup';
+
+import useInput from '@/hooks/common/useInput';
+import useDidUpdate from '@/hooks/life-cycle/useDidUpdate';
+
+type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
+
+const RADIO_CATEGORY_NAME = 'category';
+
+const CategoryAppendBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
+  const {
+    value: categoryName,
+    onChange: onChangeCategoryName,
+    debouncedValue: debouncedCategoryName,
+  } = useInput({ initialValue: '', useDebounce: true });
+
+  // TODO: API 부착 시 [group, setGroup]
+  const [_, setGroup] = useState<string>('일상');
+  const onClickGroup = (e: MouseEvent<HTMLInputElement>) => {
+    setGroup(e.currentTarget.value);
+  };
+
+  const [currentIcon, setCurrentIcon] = useState<string | null>(null);
+
+  const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(false);
+  useDidUpdate(() => {
+    const isDisabled = debouncedCategoryName.length === 0 || currentIcon === null;
+    setIsSubmitDisabled(isDisabled);
+  }, [debouncedCategoryName, currentIcon]);
+
+  return (
+    <BottomSheet isShowing={isShowing} setToClose={setToClose}>
+      <Wrapper>
+        <AppBar
+          title="카테고리 추가"
+          onClickBackButton={setToClose}
+          rightElement={
+            <LabelButton size="large" disabled={isSubmitDisabled}>
+              완료
+            </LabelButton>
+          }
+          isAbsolute
+        />
+        <Form>
+          <TextField value={categoryName} onChange={onChangeCategoryName} placeholder="카테고리 입력" />
+
+          <fieldset>
+            <Legend style={{ marginBottom: '8px' }}>분류 *</Legend>
+            <div style={{ width: '100%', display: 'flex', gap: '8px' }}>
+              <RadioItem name={RADIO_CATEGORY_NAME} value="일상" defaultChecked onClick={onClickGroup} />
+              <RadioItem name={RADIO_CATEGORY_NAME} value="여행" onClick={onClickGroup} />
+              <RadioItem name={RADIO_CATEGORY_NAME} value="운동" onClick={onClickGroup} />
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <Legend>아이콘 *</Legend>
+            <IconRadioGroup currentValue={currentIcon} setCurrentValue={setCurrentIcon} />
+          </fieldset>
+        </Form>
+      </Wrapper>
+    </BottomSheet>
+  );
+};
+
+export default CategoryAppendBottomSheet;
+
+const Wrapper = styled.div({ height: '100vh' });
+
+const Form = styled.form({
+  marginTop: '8px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+});
+
+const Legend = styled.legend(({ theme }) => ({ ...theme.typographies.caption1, color: theme.colors.gray6 }));
+
+type RadioItemProps = InputHTMLAttributes<HTMLInputElement>;
+
+const RadioItem: FC<RadioItemProps> = ({ value, ...rest }) => {
+  const id = useId();
+
+  return (
+    <>
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <HidedInput type="radio" id={id} value={value} {...rest} />
+      <ItemLabel htmlFor={id}>{value}</ItemLabel>
+    </>
+  );
+};
+
+const HidedInput = styled.input(
+  {
+    position: 'absolute',
+    appearance: 'none',
+    clipPath: 'polygon(0 0, 0 0, 0 0)',
+  },
+  ({ theme }) => ({
+    '&:checked + label': {
+      backgroundColor: theme.colors.gray4,
+      color: theme.colors.white,
+    },
+  }),
+);
+
+const ItemLabel = styled.label(
+  {
+    cursor: 'pointer',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: '38px',
+    borderRadius: '8px',
+    transition: 'background-color .3s, color .3s',
+  },
+  ({ theme }) => ({
+    ...theme.typographies.button2,
+    color: theme.colors.gray4,
+    backgroundColor: theme.colors.gray1,
+  }),
+);

--- a/src/components/route-home/CategorySettingBottomSheet.tsx
+++ b/src/components/route-home/CategorySettingBottomSheet.tsx
@@ -7,9 +7,15 @@ import IconChevron24pxRightLeft from '../icon/IconChevron24pxRightLeft';
 import AppBar from '../navigation/AppBar';
 import BottomSheet from '../portal/BottomSheet';
 
+import CategoryAppendBottomSheet from './CategoryAppendBottomSheet';
+
+import useToggle from '@/hooks/common/useToggle';
+
 type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
 
 const CategorySettingBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
+  const [isCategoryAppendShowing, setIsCategoryAppendShowing, toggleIsCategoryAppendShowing] = useToggle(false);
+
   const testFn = () => {
     // TODO: 이후 대응
     // eslint-disable-next-line no-console
@@ -17,19 +23,26 @@ const CategorySettingBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
   };
 
   return (
-    <BottomSheet isShowing={isShowing} setToClose={setToClose}>
-      <Wrapper>
-        <AppBar title="카테고리 설정" onClickBackButton={setToClose} isAbsolute />
+    <>
+      <BottomSheet isShowing={isShowing} setToClose={setToClose}>
+        <Wrapper>
+          <AppBar title="카테고리 설정" onClickBackButton={setToClose} isAbsolute />
 
-        <CategoryItem icon={<IconAdd />} label="일상" onClick={testFn} />
-        <CategoryItem icon={<IconAdd />} label="여행" onClick={testFn} />
+          <CategoryItem icon={<IconAdd />} label="일상" onClick={testFn} />
+          <CategoryItem icon={<IconAdd />} label="여행" onClick={testFn} />
 
-        <PadlessLabelButton size="large">
-          <IconAdd />
-          추가하기
-        </PadlessLabelButton>
-      </Wrapper>
-    </BottomSheet>
+          <PadlessLabelButton size="large" onClick={toggleIsCategoryAppendShowing}>
+            <IconAdd />
+            추가하기
+          </PadlessLabelButton>
+        </Wrapper>
+      </BottomSheet>
+
+      <CategoryAppendBottomSheet
+        isShowing={isCategoryAppendShowing}
+        setToClose={() => setIsCategoryAppendShowing(false)}
+      />
+    </>
   );
 };
 

--- a/src/components/route-home/IconRadioGroup.tsx
+++ b/src/components/route-home/IconRadioGroup.tsx
@@ -1,0 +1,84 @@
+import { cloneElement, Dispatch, FC, Fragment, MouseEvent, ReactElement, SetStateAction, useId } from 'react';
+import styled from '@emotion/styled';
+
+import GraphicBowling from '../graphic/GraphicBowling';
+import GraphicBus from '../graphic/GraphicBus';
+import GraphicCamera from '../graphic/GraphicCamera';
+import GraphicEtc from '../graphic/GraphicEtc';
+import GraphicFriends from '../graphic/GraphicFriends';
+import GraphicGym from '../graphic/GraphicGym';
+import GraphicPlane from '../graphic/GraphicPlane';
+import GraphicRun from '../graphic/GraphicRun';
+import GraphicSchool from '../graphic/GraphicSchool';
+import GraphicSwim from '../graphic/GraphicSwim';
+import GraphicTube from '../graphic/GraphicTube';
+import GraphicWork from '../graphic/GraphicWork';
+
+interface Graphic {
+  value: string;
+  reactElement: ReactElement;
+}
+
+const GRAPHICS: Graphic[] = [
+  { value: 'bowling', reactElement: <GraphicBowling /> },
+  { value: 'bus', reactElement: <GraphicBus /> },
+  { value: 'camera', reactElement: <GraphicCamera /> },
+  { value: 'etc', reactElement: <GraphicEtc /> },
+  { value: 'friends', reactElement: <GraphicFriends /> },
+  { value: 'gym', reactElement: <GraphicGym /> },
+  { value: 'plane', reactElement: <GraphicPlane /> },
+  { value: 'run', reactElement: <GraphicRun /> },
+  { value: 'school', reactElement: <GraphicSchool /> },
+  { value: 'swim', reactElement: <GraphicSwim /> },
+  { value: 'tube', reactElement: <GraphicTube /> },
+  { value: 'work', reactElement: <GraphicWork /> },
+];
+
+interface Props {
+  currentValue: string | null;
+  setCurrentValue: Dispatch<SetStateAction<string | null>>;
+}
+
+const IconRadioGroup: FC<Props> = ({ currentValue, setCurrentValue }) => {
+  const id = useId();
+
+  const onClick = (e: MouseEvent<HTMLInputElement>) => {
+    setCurrentValue(e.currentTarget.value);
+  };
+
+  return (
+    <Wrapper>
+      {GRAPHICS.map(({ value, reactElement }) => (
+        <Fragment key={value}>
+          <HidedInput type="radio" id={`${value}-${id}`} value={value} onClick={onClick} />
+          <GraphicLabel htmlFor={`${value}-${id}`}>
+            {cloneElement(reactElement, { isAct: value === currentValue })}
+          </GraphicLabel>
+        </Fragment>
+      ))}
+    </Wrapper>
+  );
+};
+
+export default IconRadioGroup;
+
+const Wrapper = styled.div({
+  display: 'flex',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+  columnGap: '8px',
+});
+
+const HidedInput = styled.input({
+  position: 'absolute',
+  appearance: 'none',
+  clipPath: 'polygon(0 0, 0 0, 0 0)',
+});
+
+const GraphicLabel = styled.label({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  width: '3rem',
+  height: '3rem',
+});

--- a/src/components/route-home/IconRadioGroup.tsx
+++ b/src/components/route-home/IconRadioGroup.tsx
@@ -13,6 +13,7 @@ import GraphicSchool from '../graphic/GraphicSchool';
 import GraphicSwim from '../graphic/GraphicSwim';
 import GraphicTube from '../graphic/GraphicTube';
 import GraphicWork from '../graphic/GraphicWork';
+import type { GraphicProps } from '../graphic/type';
 
 interface Graphic {
   value: string;
@@ -52,7 +53,7 @@ const IconRadioGroup: FC<Props> = ({ currentValue, setCurrentValue }) => {
         <Fragment key={value}>
           <HidedInput type="radio" id={`${value}-${id}`} value={value} onClick={onClick} />
           <GraphicLabel htmlFor={`${value}-${id}`}>
-            {cloneElement(reactElement, { isAct: value === currentValue })}
+            {cloneElement<GraphicProps>(reactElement, { isAct: value === currentValue })}
           </GraphicLabel>
         </Fragment>
       ))}

--- a/src/components/text-field/TextField.tsx
+++ b/src/components/text-field/TextField.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import IconCancelSmall from '../icon/IconCancelSmall';
 
-interface Props extends React.HTMLAttributes<HTMLInputElement> {
+interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
 }
 

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -20,6 +20,11 @@ export const setGlobalStyles = css`
     text-decoration: none;
   }
 
+  fieldset,
+  legend {
+    all: unset;
+  }
+
   :disabled {
     cursor: not-allowed;
   }


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?

- closes #108 
- `TextField`의 `onChange`의 타입이 `FormEventHandler<HTMLInputElement>`


## 🎉 어떻게 해결했나요?
- 이번에 알았는데, 
  TextField에 확정되어 사용되고 있던 `HTMLAttributes`의 `onChange`는 `FormEventHandler<HTMLInputElement>` 이더라구요
  https://use-form.netlify.app/interfaces/_node_modules__types_react_index_d_.react.htmlattributes.html#onchange
  
  `ChangeEvent<HTMLInputElement>`인 게 사용하는 입장에서 예측 가능한 행위인 거 같아 `InputHTMLAttributes`로 변경했어요
  https://use-form.netlify.app/interfaces/_node_modules__types_react_index_d_.react.inputhtmlattributes.html#onchange
  
  a075622c748a6d2b93019d751b99a14beede01a4

![스크린샷 2022-11-29 오후 8 58 34](https://user-images.githubusercontent.com/26461307/204523218-589974a6-cd8c-4977-b5d6-929e94d66994.png)

- `CategoryAppendBottomSheet`를 개발, 적용했어요
  - `IconRadioGroup`의 경우 다른 bottom sheet에서도 사용되어 분리했어요
  - 사용되는 `fieldset`, `legend` 태그의 기본 스타일을 `unset` 했어요

- `LabelButton`의 색상이 잘못 적용되고 있던 것을 고쳤어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 
```tsx
const isDisabled = debouncedCategoryName.length === 0 || currentIcon === null;

const isDisabled = !debouncedCategoryName || !currentIcon;
```

저는 위에가 취향인데 (더 직관적이라 생각해서) 여러분은 어떠신지 궁금해요 !