### PR TITLE
AppBar 인터페이스 변경 및 대응

### DIFF
--- a/src/components/navigation/AppBar.tsx
+++ b/src/components/navigation/AppBar.tsx
@@ -2,9 +2,11 @@ import { FC, ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import styled from '@emotion/styled';
 
+import IconCancel from '../icon/IconCancel';
 import IconChevron24pxRightLeft from '../icon/IconChevron24pxRightLeft';
 
 interface Props {
+  backButtonType?: 'chevron' | 'cancel';
   /**
    * 가운데에 표시될 텍스트
    */
@@ -23,7 +25,7 @@ interface Props {
   onClickBackButton?: VoidFunction;
 }
 
-const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
+const AppBar: FC<Props> = ({ backButtonType = 'chevron', title, rightElement, onClickBackButton }) => {
   const router = useRouter();
 
   const handleBackButton = () => {
@@ -37,7 +39,7 @@ const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
   return (
     <Wrapper>
       <BackButton onClick={handleBackButton}>
-        <IconChevron24pxRightLeft direction="left" />
+        {backButtonType === 'chevron' ? <IconChevron24pxRightLeft direction="left" /> : <IconCancel />}
       </BackButton>
       {title && <Title>{title}</Title>}
       {rightElement && <RightElementWrapper>{rightElement}</RightElementWrapper>}

--- a/src/components/navigation/AppBar.tsx
+++ b/src/components/navigation/AppBar.tsx
@@ -67,6 +67,7 @@ const Wrapper = styled.section(
 const BackButton = styled.button({
   all: 'unset',
   position: 'absolute',
+  // NOTE: - wapper padding + design padding
   left: 'calc(-20px + 8px)',
   cursor: 'pointer',
   width: '3rem',
@@ -83,5 +84,6 @@ const Title = styled.h2(({ theme }) => ({
 
 const RightElementWrapper = styled.div({
   position: 'absolute',
+  // NOTE: - wapper padding + design padding
   right: 'calc(-20px + 8px)',
 });

--- a/src/components/navigation/AppBar.tsx
+++ b/src/components/navigation/AppBar.tsx
@@ -1,6 +1,5 @@
 import { FC, ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import IconChevron24pxRightLeft from '../icon/IconChevron24pxRightLeft';
@@ -22,15 +21,9 @@ interface Props {
    * 값을 주입하지 않을 시 `router.back()`이 실행됩니다
    */
   onClickBackButton?: VoidFunction;
-  /**
-   * `BottomSheet`등에서 layout에 구애받지 않고 사용될 때 사용합니다
-   *
-   * `position`이 `absolute`가 되며, `ScrollableDiv`를 렌더링합니다
-   */
-  isAbsolute?: boolean;
 }
 
-const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton, isAbsolute = false }) => {
+const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton }) => {
   const router = useRouter();
 
   const handleBackButton = () => {
@@ -42,16 +35,13 @@ const AppBar: FC<Props> = ({ title, rightElement, onClickBackButton, isAbsolute 
   };
 
   return (
-    <>
-      <Wrapper isAbsolute={isAbsolute}>
-        <BackButton onClick={handleBackButton}>
-          <IconChevron24pxRightLeft direction="left" />
-        </BackButton>
-        {title && <Title>{title}</Title>}
-        {rightElement && rightElement}
-      </Wrapper>
-      {isAbsolute && <ScrollableDiv />}
-    </>
+    <Wrapper>
+      <BackButton onClick={handleBackButton}>
+        <IconChevron24pxRightLeft direction="left" />
+      </BackButton>
+      {title && <Title>{title}</Title>}
+      {rightElement && <RightElementWrapper>{rightElement}</RightElementWrapper>}
+    </Wrapper>
   );
 };
 
@@ -59,7 +49,7 @@ export default AppBar;
 
 const APP_BAR_HEIGHT = '48px';
 
-const Wrapper = styled.section<{ isAbsolute: boolean }>(
+const Wrapper = styled.section(
   {
     position: 'sticky',
     left: 0,
@@ -67,24 +57,17 @@ const Wrapper = styled.section<{ isAbsolute: boolean }>(
     width: '100%',
     height: APP_BAR_HEIGHT,
     display: 'flex',
-    justifyContent: 'space-between',
+    justifyContent: 'center',
     alignItems: 'center',
-    padding: '0 4px',
     zIndex: '900',
   },
   ({ theme }) => ({ backgroundColor: theme.colors.white }),
-  ({ isAbsolute }) => isAbsolute && AbsoluteCss,
 );
-
-const AbsoluteCss = css({
-  position: 'absolute',
-  top: '0',
-  left: '0',
-  marginTop: '16px',
-});
 
 const BackButton = styled.button({
   all: 'unset',
+  position: 'absolute',
+  left: 'calc(-20px + 8px)',
   cursor: 'pointer',
   width: '3rem',
   height: '3rem',
@@ -93,18 +76,12 @@ const BackButton = styled.button({
   alignItems: 'center',
 });
 
-const Title = styled.h2(
-  {
-    margin: 0,
-    position: 'absolute',
-    top: '50%',
-    left: '50%',
-    transform: 'translate(-50%, -50%)',
-  },
-  ({ theme }) => ({
-    ...theme.typographies.subTitle,
-    color: theme.colors.gray6,
-  }),
-);
+const Title = styled.h2(({ theme }) => ({
+  ...theme.typographies.subTitle,
+  color: theme.colors.gray6,
+}));
 
-const ScrollableDiv = styled.div({ height: APP_BAR_HEIGHT });
+const RightElementWrapper = styled.div({
+  position: 'absolute',
+  right: 'calc(-20px + 8px)',
+});

--- a/src/components/route-home/CategoryAppendBottomSheet.tsx
+++ b/src/components/route-home/CategoryAppendBottomSheet.tsx
@@ -40,6 +40,7 @@ const CategoryAppendBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
     <BottomSheet isShowing={isShowing} setToClose={setToClose}>
       <Wrapper>
         <AppBar
+          backButtonType="cancel"
           title="카테고리 추가"
           onClickBackButton={setToClose}
           rightElement={

--- a/src/components/route-home/CategoryAppendBottomSheet.tsx
+++ b/src/components/route-home/CategoryAppendBottomSheet.tsx
@@ -47,7 +47,6 @@ const CategoryAppendBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
               완료
             </LabelButton>
           }
-          isAbsolute
         />
         <Form>
           <TextField value={categoryName} onChange={onChangeCategoryName} placeholder="카테고리 입력" />

--- a/src/components/route-home/CategorySettingBottomSheet.tsx
+++ b/src/components/route-home/CategorySettingBottomSheet.tsx
@@ -26,7 +26,7 @@ const CategorySettingBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
     <>
       <BottomSheet isShowing={isShowing} setToClose={setToClose}>
         <Wrapper>
-          <AppBar title="카테고리 설정" onClickBackButton={setToClose} />
+          <AppBar backButtonType="cancel" title="카테고리 설정" onClickBackButton={setToClose} />
 
           <CategoryItem icon={<IconAdd />} label="일상" onClick={testFn} />
           <CategoryItem icon={<IconAdd />} label="여행" onClick={testFn} />

--- a/src/components/route-home/CategorySettingBottomSheet.tsx
+++ b/src/components/route-home/CategorySettingBottomSheet.tsx
@@ -26,7 +26,7 @@ const CategorySettingBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
     <>
       <BottomSheet isShowing={isShowing} setToClose={setToClose}>
         <Wrapper>
-          <AppBar title="카테고리 설정" onClickBackButton={setToClose} isAbsolute />
+          <AppBar title="카테고리 설정" onClickBackButton={setToClose} />
 
           <CategoryItem icon={<IconAdd />} label="일상" onClick={testFn} />
           <CategoryItem icon={<IconAdd />} label="여행" onClick={testFn} />

--- a/src/pages/notice/index.page.tsx
+++ b/src/pages/notice/index.page.tsx
@@ -8,7 +8,6 @@ const Notice = () => {
   return (
     <>
       <WhiteBackgroundGlobalStyles />
-      {/* TODO: #106 이후 패딩 대응 */}
       <AppBar title="알림" />
       <Main>
         <NoticeItem icon="&#127911;" title="아맞다! 이어폰은 꼭 챙기셔야 해요!" time="1초 전" />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- closes #115 
- 기존 `AppBar` 컴포넌트에서 `isAbsolute`를 받고 있었어요.
  근데 페이지에 적용되는 AppBar와 BottomSheet에서 적용되는 AppBar 모두 좌우에 위치할 버튼이 레이아웃 밖에 위치하더라구요
- 왼쪽에 위치하는 버튼의 종류가 2종류로 나뉘었어요

## 🎉 어떻게 해결했나요?
- 더욱 일관성 있게 사용되기 위해 `isAbsolute`를 지우고, 양쪽에 위치하는 버튼들을 `absolute` 위치로 변경했어요

- `backButtonType` props를 추가했어요


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

![스크린샷 2022-11-30 오후 7 03 21](https://user-images.githubusercontent.com/26461307/204766895-e0c2cd32-e2b4-4c67-a849-189e30becb54.png)

 
![스크린샷 2022-11-30 오후 7 03 32](https://user-images.githubusercontent.com/26461307/204766920-77055354-9d72-4b50-b2c9-bcaa3fbf8720.png)
