### PR TITLE
[홈] 리스트 설정 BottomSheet 마크업

### DIFF
--- a/src/components/route-home/ListSettingBottomSheet.tsx
+++ b/src/components/route-home/ListSettingBottomSheet.tsx
@@ -1,0 +1,114 @@
+import { ComponentProps, useState } from 'react';
+import styled from '@emotion/styled';
+
+import LabelButton from '../button/LabelButton';
+import AppBar from '../navigation/AppBar';
+import BottomSheet from '../portal/BottomSheet';
+import Dialog from '../portal/Dialog';
+import TextField from '../text-field/TextField';
+import ToggleSwitch from '../toggle/ToggleSwitch';
+
+import useInput from '@/hooks/common/useInput';
+import useDidUpdate from '@/hooks/life-cycle/useDidUpdate';
+
+type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
+
+const ListSettingBottomSheet = ({ isShowing, setToClose }: Props) => {
+  const {
+    value: listName,
+    onChange: onChangeListName,
+    debouncedValue: debouncedListName,
+  } = useInput({ initialValue: '', useDebounce: true });
+  const [isDialogShowing, setIsDialogShowing] = useState(false);
+  const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(false);
+
+  useDidUpdate(() => {
+    const isDisabled = debouncedListName.length === 0;
+    setIsSubmitDisabled(isDisabled);
+  }, [debouncedListName]);
+
+  const handleListSettingComplete = () => {
+    // TODO: 리스트 설정 완료 시 실행할 로직 추가
+    setToClose();
+  };
+
+  return (
+    <BottomSheet isShowing={isShowing} setToClose={setToClose}>
+      <AppBar
+        backButtonType="cancel"
+        title="리스트 설정"
+        rightElement={
+          <LabelButton disabled={isSubmitDisabled} onClick={handleListSettingComplete} size="large">
+            완료
+          </LabelButton>
+        }
+        onClickBackButton={setToClose}
+      />
+      <div style={{ marginTop: 8 }}>
+        <TextField value={listName} onChange={onChangeListName} />
+      </div>
+      <SettingOptionList>
+        <Option>
+          <span>매일 반복</span>
+          <ToggleSwitch />
+        </Option>
+        <Option
+          isDeleteOption
+          onClick={() => {
+            setIsDialogShowing(true);
+          }}
+        >
+          리스트 삭제하기
+        </Option>
+      </SettingOptionList>
+      <Dialog
+        setToClose={() => {
+          setIsDialogShowing(false);
+        }}
+        isShowing={isDialogShowing}
+        content={DialogContent}
+        leftButton={
+          <Dialog.Button
+            onClick={() => {
+              setIsDialogShowing(false);
+            }}
+          >
+            아니요
+          </Dialog.Button>
+        }
+        rightButton={<Dialog.WarningButton>삭제하기</Dialog.WarningButton>}
+      />
+    </BottomSheet>
+  );
+};
+
+export default ListSettingBottomSheet;
+
+const SettingOptionList = styled.ul`
+  margin-top: 16px;
+`;
+
+interface OptionProps {
+  isDeleteOption?: boolean;
+}
+
+const Option = styled('li')<OptionProps>(
+  {
+    paddingBlock: 12,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    '&:last-child': {
+      border: 0,
+    },
+  },
+  ({ theme }) => ({ ...theme.typographies.body1, ...theme.divider }),
+  (props) => props.isDeleteOption && { color: props.theme.colors.danger },
+);
+
+const DialogContent = (
+  <>
+    <Dialog.ContentTitle>리스트를 삭제할까요?</Dialog.ContentTitle>
+    <Dialog.ContentBody>리스트 안의 소지품까지 모두 사라져요.</Dialog.ContentBody>
+  </>
+);

--- a/src/components/route-search/TemplateAppendBottomSheet.tsx
+++ b/src/components/route-search/TemplateAppendBottomSheet.tsx
@@ -1,0 +1,68 @@
+import { ComponentProps } from 'react';
+import styled from '@emotion/styled';
+
+import LabelButton from '../button/LabelButton';
+import IconAdd from '../icon/IconAdd';
+import AppBar from '../navigation/AppBar';
+import BottomSheet from '../portal/BottomSheet';
+
+import CategorySection from './CategorySection';
+
+type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
+
+const TemplateAppendBottomSheet = ({ isShowing, setToClose }: Props) => {
+  return (
+    <BottomSheet isShowing={isShowing} setToClose={setToClose}>
+      <AppBar
+        backButtonType="cancel"
+        title="추가하기"
+        rightElement={<LabelButton size="large">완료</LabelButton>}
+        onClickBackButton={setToClose}
+      />
+      <div style={{ marginTop: 8 }}>
+        <CategorySection defaultColor="gray" />
+      </div>
+      <List>
+        <ListItem>기존 리스트 1</ListItem>
+        <ListItem>기존 리스트 2</ListItem>
+        <ListItem newItem selected>
+          <IconAdd />
+          디프만 UT 준비물로 리스트 추가
+        </ListItem>
+      </List>
+    </BottomSheet>
+  );
+};
+
+export default TemplateAppendBottomSheet;
+
+const List = styled.ul`
+  list-style: none;
+  margin-top: 24px;
+`;
+
+interface ListItemProps {
+  newItem?: boolean;
+  selected?: boolean;
+}
+
+const ListItem = styled('li')<ListItemProps>(
+  {
+    display: 'flex',
+    width: 'calc(100% + 20px * 2)',
+    alignItems: 'center',
+    height: 48,
+    marginLeft: -20,
+    paddingLeft: 20,
+  },
+  ({ theme }) => ({
+    borderBottom: `1px solid ${theme.colors.gray1}`,
+    color: `${theme.colors.gray6}`,
+  }),
+  (props) => props.newItem && { color: props.theme.colors.gray3, borderBottom: 'none' },
+  (props) =>
+    props.selected && {
+      backgroundColor: props.theme.colors.gray1,
+      boxShadow: '0px 4px 4px 0px #00000040',
+    },
+);

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -7,10 +7,14 @@ import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-home/CategorySection';
 import EmptyCard from '@/components/route-home/EmptyCard';
+import ListSettingBottomSheet from '@/components/route-home/ListSettingBottomSheet';
 import RecommendSection from '@/components/route-home/RecommendSection';
 
 const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
+
+  // TODO: Home Card 컴포넌트 개발 시 해당 컴포넌트 내부로 이동 예정
+  const [isShowing, setIsShowing] = useState(false);
 
   return (
     <>
@@ -25,6 +29,20 @@ const HomePage: NextPageWithLayout = () => {
       <Carousel.Indicator carouselWrapper={carouselWrapper} />
 
       <RecommendSection />
+      <button
+        onClick={() => {
+          setIsShowing(true);
+        }}
+        type="button"
+      >
+        리스트 설정 BottomSheet 열기
+      </button>
+      <ListSettingBottomSheet
+        isShowing={isShowing}
+        setToClose={() => {
+          setIsShowing(false);
+        }}
+      />
     </>
   );
 };

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -5,20 +5,14 @@ import { NextPageWithLayout } from '../_app.page';
 
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
-import BottomSheet from '@/components/portal/BottomSheet';
-import AddTemplateSection from '@/components/route-search/AddTemplateSection';
 import CategorySection from '@/components/route-search/CategorySection';
 import ListRequestSection from '@/components/route-search/ListRequestSection';
 import SearchCard from '@/components/route-search/SearchCard';
+import TemplateAppendBottomSheet from '@/components/route-search/TemplateAppendBottomSheet';
 import { mockCheckboxGroupOptions, mockCheckboxGroupTitle } from '@/fixtures/checkboxGroup.mock';
 
 const Template: NextPageWithLayout = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
-
-  const addTemplate = () => {
-    setIsBottomSheetOpen(false);
-  };
-
   return (
     <Wrapper>
       <Title>
@@ -37,14 +31,12 @@ const Template: NextPageWithLayout = () => {
         />
       </CardsWrapper>
       <ListRequestSection />
-      <BottomSheet
+      <TemplateAppendBottomSheet
         isShowing={isBottomSheetOpen}
         setToClose={() => {
           setIsBottomSheetOpen(false);
         }}
-      >
-        <AddTemplateSection onComplete={addTemplate} />
-      </BottomSheet>
+      />
     </Wrapper>
   );
 };

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -63,6 +63,9 @@ const theme = {
     maxWidth: '480px',
     layoutPadding: '0 20px',
   },
+  divider: {
+    borderBottom: '1px solid #F5F5F9',
+  },
 } as const;
 
 export default theme;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- closes #121
- theme에 list divider를 추가했어요
<img width="576" alt="image" src="https://user-images.githubusercontent.com/87167786/205120701-a39d0695-4dff-41c4-9095-0b69bca1da44.png">
여기 가운데 있는 회색 줄

## 🎉 어떻게 해결했나요?
- 홈의 Card 컴포넌트가 아직 merge 안돼서, 우선 BottomSheet를 열고 닫을 수 있는 임시 버튼을 추가했어요
- 추후에 실제로 사용할 때에는 TextField의 initialValue를 props로 주입 받아야 할 것 같아요

이대로 괜찮으시다면 소지품 설정 BottomSheet도 동일하게 개발하겠습니다!

### 📚 Attachment (Option)
