### PR TITLE
recoil atom localStorage effect 작성

### DIFF
--- a/src/store/localStorage/effect.ts
+++ b/src/store/localStorage/effect.ts
@@ -1,0 +1,16 @@
+import { AtomEffect } from 'recoil';
+
+const localStorageEffect: <T>(key: string) => AtomEffect<T> =
+  (key: string) =>
+  ({ setSelf, onSet }) => {
+    const savedValue = localStorage.getItem(key);
+    if (savedValue !== null) {
+      setSelf(JSON.parse(savedValue));
+    }
+
+    onSet((newValue, _, isReset) =>
+      isReset ? localStorage.removeItem(key) : localStorage.setItem(key, JSON.stringify(newValue)),
+    );
+  };
+
+export default localStorageEffect;

--- a/src/store/localStorage/userId.ts
+++ b/src/store/localStorage/userId.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+import localStorageEffect from './effect';
+
+const userIdState = atom<string | null>({
+  key: 'userId',
+  default: null,
+  effects: [localStorageEffect<string | null>('user_id')],
+});
+
+export default userIdState;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- closes #135 

## 🎉 어떻게 해결했나요?
https://recoiljs.org/ko/docs/guides/atom-effects/#local-storage-persistence-%EB%A1%9C%EC%BB%AC-%EC%8A%A4%ED%86%A0%EB%A6%AC%EC%A7%80-%EC%A7%80%EC%86%8D%EC%84%B1

- 전 이전에는 localStorage 키 타입을 정의해놓고, 해당 타입만 사용할 수 있는 유틸을 개발해 사용하곤 했는데
  `recoil effect`를 사용하면 더 typesafe하고 편하게 사용할 수 있을 거 같아 적용해 봤어요

- `userIdState`는 예시이지만, 그대로 사용해도 될 거 같달까요

- 다른 의견도 좋으니 편하게 말씀 부탁드려여

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 