### PR TITLE
확대 방지 및 Head 분리 사용

### DIFF
--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, ReactElement, ReactNode, useState } from 'react';
 import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
+import NextHead from 'next/head';
 import { ThemeProvider } from '@emotion/react';
 import styled from '@emotion/styled';
 import { Hydrate, QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -44,6 +45,7 @@ const MyApp = ({ Component: AppComponent, pageProps }: AppPropsWithLayout) => {
           <ThemeProvider theme={lightTheme}>
             <LazyMotion features={domMax}>
               <DefaultLayout>
+                <Head />
                 <GlobalStyles />
                 {getLayout(<AppComponent {...pageProps} />)}
               </DefaultLayout>
@@ -69,3 +71,15 @@ const LayoutWrapper = styled.div`
   padding: ${({ theme }) => theme.size.layoutPadding};
   margin: 0 auto;
 `;
+
+const Head = () => {
+  return (
+    <NextHead>
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0 viewport-fit=cover"
+      />
+      <title>아맞다</title>
+    </NextHead>
+  );
+};

--- a/src/pages/_document.page.tsx
+++ b/src/pages/_document.page.tsx
@@ -16,7 +16,7 @@ class MyDocument extends Document {
             href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard-dynamic-subset.css"
           />
           <meta charSet="utf-8" />
-          <title>team3-web</title>
+
           {isProd(process.env.NODE_ENV) && (
             <>
               {/* GA */}

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -57,6 +57,7 @@ const HomePage: NextPageWithLayout = () => {
 
   return (
     <>
+      <a href="https://www.naver.com">asdf</a>
       <CategorySection />
 
       <Carousel.Wrapper ref={setCarouselWrapper}>

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -57,7 +57,6 @@ const HomePage: NextPageWithLayout = () => {
 
   return (
     <>
-      <a href="https://www.naver.com">asdf</a>
       <CategorySection />
 
       <Carousel.Wrapper ref={setCarouselWrapper}>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- closes #157 
- `title`이 `_document`에서 작성되어 있다는 오류가 거슬려서 같이 핸들링했어요

## 🎉 어떻게 해결했나요?
- `_app`에 `title`과 `viewport meta` 태그를 담는 컴포넌트로 사용했어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 

