### PR TITLE
카테고리 조회 API 적용 및 Graphic 컴포넌트 개발

### DIFF
--- a/src/components/graphic/Graphic.tsx
+++ b/src/components/graphic/Graphic.tsx
@@ -1,0 +1,59 @@
+import { createElement, FC } from 'react';
+
+import GraphicBowling from './GraphicBowling';
+import GraphicBus from './GraphicBus';
+import GraphicCamera from './GraphicCamera';
+import GraphicEmptyCard from './GraphicEmptyCard';
+import GraphicEtc from './GraphicEtc';
+import GraphicFriends from './GraphicFriends';
+import GraphicGym from './GraphicGym';
+import GraphicPlane from './GraphicPlane';
+import GraphicRun from './GraphicRun';
+import GraphicSchool from './GraphicSchool';
+import GraphicSwim from './GraphicSwim';
+import GraphicTube from './GraphicTube';
+import GraphicWork from './GraphicWork';
+import { Graphic, GraphicProps } from './type';
+
+const graphicElement = (type: Graphic) => {
+  switch (type) {
+    case 'BOWLING':
+      return GraphicBowling;
+    case 'BUS':
+      return GraphicBus;
+    case 'CAMERA':
+      return GraphicCamera;
+    case 'EMPTYCARD':
+      return GraphicEmptyCard;
+    case 'ETC':
+      return GraphicEtc;
+    case 'FRIENDS':
+      return GraphicFriends;
+    case 'GYM':
+      return GraphicGym;
+    case 'PLANE':
+      return GraphicPlane;
+    case 'RUN':
+      return GraphicRun;
+    case 'SCHOOL':
+      return GraphicSchool;
+    case 'SWIM':
+      return GraphicSwim;
+    case 'TUBE':
+      return GraphicTube;
+    case 'WORK':
+      return GraphicWork;
+    default:
+      return GraphicEtc;
+  }
+};
+
+interface Props extends GraphicProps {
+  type: Graphic;
+}
+
+const Graphic: FC<Props> = ({ type, isAct, ...rest }) => {
+  return createElement(graphicElement(type), { isAct, ...rest });
+};
+
+export default Graphic;

--- a/src/components/graphic/type.ts
+++ b/src/components/graphic/type.ts
@@ -6,3 +6,18 @@ export interface GraphicProps extends Props {
    */
   isAct?: boolean;
 }
+
+export type Graphic =
+  | 'BOWLING'
+  | 'BUS'
+  | 'CAMERA'
+  | 'EMPTYCARD'
+  | 'ETC'
+  | 'FRIENDS'
+  | 'GYM'
+  | 'PLANE'
+  | 'RUN'
+  | 'SCHOOL'
+  | 'SWIM'
+  | 'TUBE'
+  | 'WORK';

--- a/src/components/route-home/category/CategorySection.tsx
+++ b/src/components/route-home/category/CategorySection.tsx
@@ -7,7 +7,7 @@ import IconButton from '@/components/button/IconButton';
 import Chip from '@/components/chip/Chip';
 import Graphic from '@/components/graphic/Graphic';
 import IconOverflow from '@/components/icon/IconOverflow';
-import useGetCategories from '@/hooks/api/category/useGetCategories';
+import useGetUserCategories from '@/hooks/api/category/useGetUserCategories';
 import useToggle from '@/hooks/common/useToggle';
 import currentCategoryState from '@/store/route-home/currentCategory';
 
@@ -87,7 +87,7 @@ const OverflowWrapper = styled.div({ position: 'relative' }, ({ theme }) => ({
 }));
 
 const useCategories = () => {
-  const query = useGetCategories();
+  const query = useGetUserCategories();
   const [currentCategory, setCurrentCategory] = useRecoilState(currentCategoryState);
 
   useEffect(() => {

--- a/src/components/route-home/category/CategorySection.tsx
+++ b/src/components/route-home/category/CategorySection.tsx
@@ -1,24 +1,38 @@
+import { useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
 
 import IconButton from '@/components/button/IconButton';
 import Chip from '@/components/chip/Chip';
+import Graphic from '@/components/graphic/Graphic';
 import IconOverflow from '@/components/icon/IconOverflow';
+import useGetCategories from '@/hooks/api/category/useGetCategories';
 import useToggle from '@/hooks/common/useToggle';
+import currentCategoryState from '@/store/route-home/currentCategory';
 
 const CategorySettingBottomSheet = dynamic(() => import('./CategorySettingBottomSheet'));
 
 const CategorySection = () => {
   const [isCategorySettingShowing, setCategorySettingShowing, toggleCategorySettingShowing] = useToggle(false);
+  const { data, currentCategory } = useCategories();
 
   return (
     <>
       <Section>
         <ChipWrapper>
-          <Chip label="일상" color="black" />
-          <Chip label="일상" />
-          <Chip label="일상" />
-          <Chip label="일상" />
+          {data?.map(({ id, name, emoji }) => {
+            const isCurrentCategory = id === currentCategory?.id;
+
+            return (
+              <Chip
+                key={id}
+                label={name}
+                color={isCurrentCategory ? 'black' : 'default'}
+                icon={<Graphic type={emoji} isAct={isCurrentCategory} />}
+              />
+            );
+          })}
         </ChipWrapper>
 
         <OverflowWrapper>
@@ -71,3 +85,17 @@ const OverflowWrapper = styled.div({ position: 'relative' }, ({ theme }) => ({
     background: `linear-gradient(to right, rgba(0, 0, 0, 0), ${theme.colors.gray1} 90%)`,
   },
 }));
+
+const useCategories = () => {
+  const query = useGetCategories();
+  const [currentCategory, setCurrentCategory] = useRecoilState(currentCategoryState);
+
+  useEffect(() => {
+    if (!query.data) return;
+    if (currentCategory !== null) return;
+
+    setCurrentCategory(query.data[0]);
+  }, [query.data]);
+
+  return { ...query, currentCategory };
+};

--- a/src/hooks/api/category/type.ts
+++ b/src/hooks/api/category/type.ts
@@ -1,0 +1,8 @@
+import { Graphic } from '@/components/graphic/type';
+
+export interface Category {
+  id: number;
+  name: string;
+  type: string;
+  emoji: Graphic;
+}

--- a/src/hooks/api/category/useGetCategories.ts
+++ b/src/hooks/api/category/useGetCategories.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { Category } from './type';
+
+import { get } from '@/lib/api';
+
+interface Response {
+  result: Category[];
+}
+
+const getCategories = () => get<Response>('/category/user');
+
+const CATEGORY_QUERY_KEY = 'category';
+
+const useGetCategories = () => {
+  const query = useQuery({ queryKey: [CATEGORY_QUERY_KEY], queryFn: getCategories });
+
+  return { ...query, data: query.data?.result };
+};
+
+export default useGetCategories;

--- a/src/hooks/api/category/useGetUserCategories.ts
+++ b/src/hooks/api/category/useGetUserCategories.ts
@@ -12,10 +12,10 @@ const getCategories = () => get<Response>('/category/user');
 
 const CATEGORY_QUERY_KEY = 'category';
 
-const useGetCategories = () => {
+const useGetUserCategories = () => {
   const query = useQuery({ queryKey: [CATEGORY_QUERY_KEY], queryFn: getCategories });
 
   return { ...query, data: query.data?.result };
 };
 
-export default useGetCategories;
+export default useGetUserCategories;

--- a/src/hooks/api/category/useGetUserCategories.ts
+++ b/src/hooks/api/category/useGetUserCategories.ts
@@ -10,7 +10,7 @@ interface Response {
 
 const getCategories = () => get<Response>('/category/user');
 
-const CATEGORY_QUERY_KEY = 'category';
+const CATEGORY_QUERY_KEY = 'user_category';
 
 const useGetUserCategories = () => {
   const query = useQuery({ queryKey: [CATEGORY_QUERY_KEY], queryFn: getCategories });

--- a/src/store/route-home/currentCategory.ts
+++ b/src/store/route-home/currentCategory.ts
@@ -1,0 +1,10 @@
+import { atom } from 'recoil';
+
+import { Category } from '@/hooks/api/category/type';
+
+const currentCategoryState = atom<Category | null>({
+  key: 'currentCategoryState',
+  default: null,
+});
+
+export default currentCategoryState;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- closes #134 

- 그래픽의 ENUM 타입을 기준으로 그래픽 컴포넌트를 반환해야 함

## 🎉 어떻게 해결했나요?
- `useGetCategories`라는 이름의 custom hook을 개발했어요
  - `hooks/api/category` 이렇게 분류를 해볼까 하는데 어떻게 생각하시나요?
 
  - 사용하는 곳인 `CategorySection`에서는 전역 상태인 `currentCategory`에 대한 로직과 함께 하단에 커스텀 훅을 배치해 추상화(?)해 사용했어요


- `String Graphic Type`에 따라 그래픽 아이콘을 반환하는 `Graphic`이라는 컴포넌트를 만들었어요
  - 작업한 것처럼 `type`에 따라 switch case 밖에 생각이 안낫는데.. 최선일지는 잘 모르겠어요.
  비슷한 경험이 있다면 공유 부탁드려요! 
  - 또 문제점이라고 생각되는 것이.. 이 컴포넌트를 사용할 때는 모든 그래픽 컴포넌트가 import가 되는 점이에요 ... 


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 
![스크린샷 2022-12-14 오후 11 41 30](https://user-images.githubusercontent.com/26461307/207625891-af0fe3b9-1bb5-402e-9886-033141df3358.png)
