### PR TITLE
사용자 템플릿 조회 API 적용 및 카테고리 선택 로직 개발

### DIFF
--- a/src/components/route-home/Card.tsx
+++ b/src/components/route-home/Card.tsx
@@ -9,23 +9,17 @@ import IconSetting from '../icon/IconSetting';
 
 import CardItem from './CardItem';
 
+import { UserItem } from '@/hooks/api/template/type';
 import useToggle from '@/hooks/common/useToggle';
 
 const ListSettingBottomSheet = dynamic(() => import('./ListSettingBottomSheet'));
 
-// TODO: API 부착 이후 변경 (요소 및 선언 위치)
-export interface Item {
-  id: string;
-  isChecked: boolean;
-  name: string;
-  isImportant: boolean;
-}
 export interface Props {
   // eslint-disable-next-line react/no-unused-prop-types
-  id: string;
+  id: number;
   title: string;
   alarmCycle: string;
-  items: Item[];
+  items: UserItem[];
 }
 
 const Card = ({ title, alarmCycle, items }: Props) => {
@@ -46,8 +40,8 @@ const Card = ({ title, alarmCycle, items }: Props) => {
             추가하기
           </LabelButton>
 
-          {items.map(({ id, isChecked, isImportant, name }) => (
-            <CardItem key={id} id={id} isChecked={isChecked} isImportant={isImportant} name={name} />
+          {items.map(({ id, take, important, name }) => (
+            <CardItem key={id} id={id} take={take} important={important} name={name} />
           ))}
         </ItemWrapper>
 

--- a/src/components/route-home/CardItem.tsx
+++ b/src/components/route-home/CardItem.tsx
@@ -5,39 +5,34 @@ import styled from '@emotion/styled';
 
 import IconCardItemCheck from './IconCardItemCheck';
 
+import { UserItem } from '@/hooks/api/template/type';
 import useToggle from '@/hooks/common/useToggle';
 
 const CardItemSettingBottomSheet = dynamic(() => import('./CardItemSettingBottomSheet'));
 
 // TODO: interface 선언 위치 변경 후 대응
-interface Props {
-  // eslint-disable-next-line react/no-unused-prop-types
-  id: string;
-  isChecked: boolean;
-  name: string;
-  isImportant: boolean;
-}
+type Props = Pick<UserItem, 'id' | 'name' | 'take' | 'important'>;
 
-const CardItem = ({ isChecked, isImportant, name }: Props) => {
+const CardItem = ({ name, take, important }: Props) => {
   const id = useId();
   // TODO: API 대응
-  const [isCurrentChecked, _, toggleCurrentChecked] = useToggle(isChecked);
+  const [isCurrentChecked, _, toggleCurrentChecked] = useToggle(take);
 
   const [isCardItemSettingShowing, __, toggleIsCardItemSettingShowing] = useToggle(false);
 
   return (
     <>
-      <Wrapper isChecked={isCurrentChecked} isImportant={isImportant}>
+      <Wrapper isChecked={isCurrentChecked} isImportant={important}>
         <HidedInput id={id} type="checkbox" checked={isCurrentChecked} onChange={toggleCurrentChecked} />
         <IconLabel htmlFor={id}>
-          <IconCardItemCheck isChecked={isCurrentChecked} isImportant={isImportant} />
+          <IconCardItemCheck isChecked={isCurrentChecked} isImportant={important} />
         </IconLabel>
 
         <NameButton
           type="button"
           onClick={toggleIsCardItemSettingShowing}
           isChecked={isCurrentChecked}
-          isImportant={isImportant}
+          isImportant={important}
         >
           {name}
         </NameButton>

--- a/src/components/route-home/category/CategorySection.tsx
+++ b/src/components/route-home/category/CategorySection.tsx
@@ -15,21 +15,22 @@ const CategorySettingBottomSheet = dynamic(() => import('./CategorySettingBottom
 
 const CategorySection = () => {
   const [isCategorySettingShowing, setCategorySettingShowing, toggleCategorySettingShowing] = useToggle(false);
-  const { data, currentCategory } = useCategories();
+  const { data, currentCategory, setCurrentCategory } = useCategories();
 
   return (
     <>
       <Section>
         <ChipWrapper>
-          {data?.map(({ id, name, emoji }) => {
-            const isCurrentCategory = id === currentCategory?.id;
+          {data?.map((eachCategory) => {
+            const isCurrentCategory = eachCategory.id === currentCategory?.id;
 
             return (
               <Chip
-                key={id}
-                label={name}
+                key={eachCategory.id}
+                label={eachCategory.name}
                 color={isCurrentCategory ? 'black' : 'default'}
-                icon={<Graphic type={emoji} isAct={isCurrentCategory} />}
+                onClick={() => setCurrentCategory(eachCategory)}
+                icon={<Graphic type={eachCategory.emoji} isAct={isCurrentCategory} />}
               />
             );
           })}
@@ -97,5 +98,5 @@ const useCategories = () => {
     setCurrentCategory(query.data[0]);
   }, [query.data]);
 
-  return { ...query, currentCategory };
+  return { ...query, currentCategory, setCurrentCategory };
 };

--- a/src/hooks/api/template/useGetUserTemplate.ts
+++ b/src/hooks/api/template/useGetUserTemplate.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
+import { Category } from '../category/type';
+
+import { UserTemplate } from './type';
+
+import { get } from '@/lib/api';
+import currentCategoryState from '@/store/route-home/currentCategory';
+
+interface Response {
+  result: UserTemplate[];
+}
+
+const getUserTemplate = (categoryId: number) => get<Response>(`/template/user?category=${categoryId}`);
+
+const USER_TEMPLATE_QUERY_KEY = 'user_template';
+
+const useGetUserTemplate = () => {
+  const currentCategory = useRecoilValue(currentCategoryState);
+
+  const query = useQuery({
+    queryKey: [USER_TEMPLATE_QUERY_KEY, currentCategory?.id],
+    queryFn: () => getUserTemplate((currentCategory as Category).id),
+    enabled: Boolean(currentCategory),
+  });
+
+  return { ...query, data: query.data?.result };
+};
+
+export default useGetUserTemplate;

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -5,64 +5,26 @@ import { NextPageWithLayout } from './_app.page';
 import Carousel from '@/components/carousel/Carousel';
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
-import Card, { Props as CardType } from '@/components/route-home/Card';
+import Card from '@/components/route-home/Card';
 import CategorySection from '@/components/route-home/category/CategorySection';
 import EmptyCard from '@/components/route-home/EmptyCard';
 import RecommendSection from '@/components/route-home/RecommendSection';
-
-const MOCK_CARDS: CardType[] = [
-  {
-    title: '출근할 때 필수템',
-    alarmCycle: '매주 월 오후 6:00',
-    id: '0',
-    items: [
-      { id: '0', isChecked: false, name: '중요 소지품', isImportant: true },
-      { id: '1', isChecked: false, name: '비중요 소지품', isImportant: false },
-      { id: '2', isChecked: true, name: '체크 + 중요 소지품', isImportant: true },
-      { id: '3', isChecked: true, name: '체크 + 비중요 소지품', isImportant: false },
-      {
-        id: '4',
-        isChecked: false,
-        name: '엄청 긴 소지품소지품소지품소지품소지품소지품소지품소지품소지품소지품',
-        isImportant: false,
-      },
-      { id: '5', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '6', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '7', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '8', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '9', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '10', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '11', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '12', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '13', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '14', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-      { id: '15', isChecked: false, name: '스크롤을 위한 소지품', isImportant: false },
-    ],
-  },
-  {
-    title: '혹한기에서 살아남기',
-    alarmCycle: '매주 화 오후 6:00',
-    id: '1',
-    items: [
-      { id: '16', isChecked: false, name: '중요 소지품', isImportant: true },
-      { id: '17', isChecked: false, name: '비중요 소지품', isImportant: false },
-      { id: '18', isChecked: true, name: '체크 + 중요 소지품', isImportant: true },
-      { id: '19', isChecked: true, name: '체크 + 비중요 소지품', isImportant: false },
-    ],
-  },
-];
+import useGetUserTemplate from '@/hooks/api/template/useGetUserTemplate';
 
 const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
+
+  const { data } = useGetUserTemplate();
 
   return (
     <>
       <CategorySection />
 
       <Carousel.Wrapper ref={setCarouselWrapper}>
-        {MOCK_CARDS.map(({ id, title, alarmCycle, items }) => (
+        {data?.map(({ id, templateName, items }) => (
           <Carousel.Item key={id}>
-            <Card id={id} title={title} alarmCycle={alarmCycle} items={items} />
+            {/* TODO: 알림 관련 API 수정 이후 대응 */}
+            <Card id={id} title={templateName} alarmCycle="매주 화 오후 6:00" items={items} />
           </Carousel.Item>
         ))}
 

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -3,6 +3,7 @@ import { ReactElement, useState } from 'react';
 import { NextPageWithLayout } from './_app.page';
 
 import Carousel from '@/components/carousel/Carousel';
+import LoadingHandler from '@/components/loading/LoadingHandler';
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import Card from '@/components/route-home/Card';
@@ -14,26 +15,28 @@ import useGetUserTemplate from '@/hooks/api/template/useGetUserTemplate';
 const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
 
-  const { data } = useGetUserTemplate();
+  const { data, isLoading } = useGetUserTemplate();
 
   return (
     <>
       <CategorySection />
 
-      <Carousel.Wrapper ref={setCarouselWrapper}>
-        {data?.map(({ id, templateName, items }) => (
-          <Carousel.Item key={id}>
-            {/* TODO: 알림 관련 API 수정 이후 대응 */}
-            <Card id={id} title={templateName} alarmCycle="매주 화 오후 6:00" items={items} />
+      <LoadingHandler fallback={<>loading...</>} isLoading={isLoading}>
+        <Carousel.Wrapper ref={setCarouselWrapper}>
+          {data?.map(({ id, templateName, items }) => (
+            <Carousel.Item key={id}>
+              {/* TODO: 알림 관련 API 수정 이후 대응 */}
+              <Card id={id} title={templateName} alarmCycle="매주 화 오후 6:00" items={items} />
+            </Carousel.Item>
+          ))}
+
+          <Carousel.Item>
+            <EmptyCard />
           </Carousel.Item>
-        ))}
+        </Carousel.Wrapper>
 
-        <Carousel.Item>
-          <EmptyCard />
-        </Carousel.Item>
-      </Carousel.Wrapper>
-
-      <Carousel.Indicator carouselWrapper={carouselWrapper} />
+        <Carousel.Indicator carouselWrapper={carouselWrapper} />
+      </LoadingHandler>
 
       <RecommendSection />
     </>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #164 close #188 

## 🎉 어떻게 해결했나요?
- 은지님이 선언해주신 API type을 기준으로 적용했어요
  - 관련해서 사용되는 컴포넌트의 인터페이스를 수정했어요

- 사용자 템플릿을 조회하는 과정에서, 카테고리가 선택되기 이전을 대응하기 위해
`enabled` 속성을 사용했어요.

  이 때 `queryFn`에서 타입 단언이 사용되었는데, 최선일지는 모르겠어요 🤔 

```tsx
const query = useQuery({
  queryKey: [USER_TEMPLATE_QUERY_KEY, currentCategory?.id],
  queryFn: () => getUserTemplate((currentCategory as Category).id),
  enabled: Boolean(currentCategory),
});
```

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 