### PR TITLE
앱 접속 시 FCM 토큰을 서버로 전송 🧚‍♀️

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -120,6 +120,7 @@ module.exports = {
       'warn',
       { html: 'ignore', exceptions: ['Button', 'AppComponent', 'Input', 'Svg'] },
     ],
+    'react/jsx-no-useless-fragment': ['error', { allowExpressions: true }],
     'import/order': 'off',
     'consistent-return': 'off',
     'jsx-a11y/label-has-associated-control': [

--- a/src/components/push-notification/FcmTokenHandler.tsx
+++ b/src/components/push-notification/FcmTokenHandler.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+
+import useSendFcmToken from '@/hooks/api/pushAlarm/useSendFcmToken';
+import useGetFCMTokenFromApp from '@/hooks/pushAlarm/useGetFCMTokenFromApp';
+
+interface FcmTokenHandlerProps {
+  children: ReactNode;
+}
+
+const FcmTokenHandler = ({ children }: FcmTokenHandlerProps) => {
+  useGetFCMTokenFromApp();
+  useSendFcmToken();
+
+  return <>{children}</>;
+};
+
+export default FcmTokenHandler;

--- a/src/hooks/api/pushAlarm/useSendFcmToken.ts
+++ b/src/hooks/api/pushAlarm/useSendFcmToken.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
+import { post } from '@/lib/api';
+import fcmTokenState from '@/store/localStorage/fcmToken';
+
+interface sendFcmTokenRequest {
+  fcmToken: string;
+}
+
+const useSendFcmToken = () => {
+  const fcmToken = useRecoilValue(fcmTokenState);
+  if (!fcmToken) {
+    throw new Error('fcm token reception failed');
+  }
+  const requestData: sendFcmTokenRequest = {
+    fcmToken,
+  };
+
+  const sendCardItemMutation = useMutation(() => {
+    return post('/user/token', requestData);
+  });
+
+  const { mutate } = sendCardItemMutation;
+
+  useEffect(() => {
+    mutate();
+  }, [mutate]);
+};
+
+export default useSendFcmToken;

--- a/src/hooks/api/pushAlarm/useSendFcmToken.ts
+++ b/src/hooks/api/pushAlarm/useSendFcmToken.ts
@@ -3,17 +3,17 @@ import { useMutation } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
 import { post } from '@/lib/api';
-import fcmTokenState from '@/store/localStorage/fcmToken';
+import userTokenState from '@/store/localStorage/userToken';
+import fcmTokenState from '@/store/push-notification/fcmToken';
 
 interface sendFcmTokenRequest {
-  fcmToken: string;
+  fcmToken: string | null;
 }
 
 const useSendFcmToken = () => {
   const fcmToken = useRecoilValue(fcmTokenState);
-  if (!fcmToken) {
-    throw new Error('fcm token reception failed');
-  }
+  const userToken = useRecoilValue(userTokenState);
+
   const requestData: sendFcmTokenRequest = {
     fcmToken,
   };
@@ -25,8 +25,10 @@ const useSendFcmToken = () => {
   const { mutate } = sendCardItemMutation;
 
   useEffect(() => {
-    mutate();
-  }, [mutate]);
+    if (fcmToken && userToken) {
+      mutate();
+    }
+  }, [mutate, fcmToken, userToken]);
 };
 
 export default useSendFcmToken;

--- a/src/hooks/pushAlarm/useGetFCMTokenFromApp.ts
+++ b/src/hooks/pushAlarm/useGetFCMTokenFromApp.ts
@@ -1,18 +1,10 @@
-import { useSetRecoilState } from 'recoil';
-
 import useListeningAppMessage from '../bridge/useListeningAppMessage';
 
-import fcmTokenState from '@/store/pushAlarm/fcmToken';
-
 const useGetFCMTokenFromApp = () => {
-  const setFCMToken = useSetRecoilState(fcmTokenState);
-
   useListeningAppMessage({
     targetType: 'FCM_TOKEN',
     handler: ({ data }) => {
-      setFCMToken(data as string);
-      // eslint-disable-next-line no-console
-      console.log('FCM token from app', data);
+      localStorage.setItem('fcm_token', JSON.stringify(data));
     },
   });
 };

--- a/src/hooks/pushAlarm/useGetFCMTokenFromApp.ts
+++ b/src/hooks/pushAlarm/useGetFCMTokenFromApp.ts
@@ -1,10 +1,15 @@
+import { useSetRecoilState } from 'recoil';
+
 import useListeningAppMessage from '../bridge/useListeningAppMessage';
 
+import fcmTokenState from '@/store/push-notification/fcmToken';
+
 const useGetFCMTokenFromApp = () => {
+  const setFcmToken = useSetRecoilState(fcmTokenState);
   useListeningAppMessage({
     targetType: 'FCM_TOKEN',
     handler: ({ data }) => {
-      localStorage.setItem('fcm_token', JSON.stringify(data));
+      setFcmToken(data as string);
     },
   });
 };

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -10,9 +10,9 @@ import { domMax, LazyMotion } from 'framer-motion';
 import { RecoilRoot } from 'recoil';
 
 import ToastWrapper from '@/components/portal/ToastWrapper';
+import FcmTokenHandler from '@/components/push-notification/FcmTokenHandler';
 import RouteGuard from '@/components/route-guard/RouteGuard';
 import useTrackPageView from '@/hooks/analytics/useTrackPageView';
-import useGetFCMTokenFromApp from '@/hooks/pushAlarm/useGetFCMTokenFromApp';
 import GlobalStyles from '@/styles/GlobalStyles';
 import lightTheme from '@/styles/theme';
 
@@ -40,7 +40,6 @@ const MyApp = ({ Component: AppComponent, pageProps }: AppPropsWithLayout) => {
   );
 
   useTrackPageView();
-  useGetFCMTokenFromApp();
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -48,12 +47,14 @@ const MyApp = ({ Component: AppComponent, pageProps }: AppPropsWithLayout) => {
         <RecoilRoot>
           <ThemeProvider theme={lightTheme}>
             <LazyMotion features={domMax}>
-              <DefaultLayout>
-                <Head />
-                <GlobalStyles />
-                <RouteGuard>{getLayout(<AppComponent {...pageProps} />)}</RouteGuard>
-                <ToastWrapper />
-              </DefaultLayout>
+              <FcmTokenHandler>
+                <DefaultLayout>
+                  <Head />
+                  <GlobalStyles />
+                  <RouteGuard>{getLayout(<AppComponent {...pageProps} />)}</RouteGuard>
+                  <ToastWrapper />
+                </DefaultLayout>
+              </FcmTokenHandler>
             </LazyMotion>
           </ThemeProvider>
         </RecoilRoot>

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -12,6 +12,7 @@ import { RecoilRoot } from 'recoil';
 import ToastWrapper from '@/components/portal/ToastWrapper';
 import RouteGuard from '@/components/route-guard/RouteGuard';
 import useTrackPageView from '@/hooks/analytics/useTrackPageView';
+import useGetFCMTokenFromApp from '@/hooks/pushAlarm/useGetFCMTokenFromApp';
 import GlobalStyles from '@/styles/GlobalStyles';
 import lightTheme from '@/styles/theme';
 
@@ -39,6 +40,7 @@ const MyApp = ({ Component: AppComponent, pageProps }: AppPropsWithLayout) => {
   );
 
   useTrackPageView();
+  useGetFCMTokenFromApp();
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -10,7 +10,6 @@ import Card from '@/components/route-home/Card';
 import CategorySection from '@/components/route-home/category/CategorySection';
 import EmptyCard from '@/components/route-home/EmptyCard';
 import RecommendSection from '@/components/route-home/RecommendSection';
-import useSendFcmToken from '@/hooks/api/pushAlarm/useSendFcmToken';
 import useGetUserTemplate from '@/hooks/api/template/useGetUserTemplate';
 import useCurrentUserTemplate from '@/hooks/route-home/useCurrentUserTemplate';
 
@@ -18,8 +17,6 @@ const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
   const { data, isLoading } = useGetUserTemplate();
   const { onCarouselIndexChange } = useCurrentUserTemplate();
-
-  useSendFcmToken();
 
   return (
     <>

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,5 +1,4 @@
 import { ReactElement, useState } from 'react';
-import { useRecoilState } from 'recoil';
 
 import { NextPageWithLayout } from './_app.page';
 
@@ -13,33 +12,15 @@ import EmptyCard from '@/components/route-home/EmptyCard';
 import RecommendSection from '@/components/route-home/RecommendSection';
 import useGetUserTemplate from '@/hooks/api/template/useGetUserTemplate';
 import useCurrentUserTemplate from '@/hooks/route-home/useCurrentUserTemplate';
-import useListeningAppMessage from '@/hooks/bridge/useListeningAppMessage';
-import fcmTokenState from '@/store/pushAlarm/fcmToken';
 
 const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
   const { data, isLoading } = useGetUserTemplate();
-
   const { onCarouselIndexChange } = useCurrentUserTemplate();
-  
-  const [fcmToken, setFcmToken] = useState<string>('no token');
-  const [globalFcmToken, setGlobalFcmToken] = useRecoilState(fcmTokenState);
-
-  useListeningAppMessage({
-    targetType: 'FCM_TOKEN',
-    handler: ({ data: token }) => {
-      // eslint-disable-next-line no-console
-      console.log('FCM token from app', token);
-      setFcmToken(token as string);
-      setGlobalFcmToken(token as string);
-    },
-  });
 
   return (
     <>
       <CategorySection />
-      <div>{`received token ➡️ ${fcmToken}`}</div>
-      <div>{`token in atom ➡️ ${globalFcmToken}`}</div>
       <LoadingHandler fallback={<>loading...</>} isLoading={isLoading}>
         <Carousel.Wrapper ref={setCarouselWrapper}>
           {data?.map(({ id, templateName, items }) => (

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -10,6 +10,7 @@ import Card from '@/components/route-home/Card';
 import CategorySection from '@/components/route-home/category/CategorySection';
 import EmptyCard from '@/components/route-home/EmptyCard';
 import RecommendSection from '@/components/route-home/RecommendSection';
+import useSendFcmToken from '@/hooks/api/pushAlarm/useSendFcmToken';
 import useGetUserTemplate from '@/hooks/api/template/useGetUserTemplate';
 import useCurrentUserTemplate from '@/hooks/route-home/useCurrentUserTemplate';
 
@@ -17,6 +18,8 @@ const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
   const { data, isLoading } = useGetUserTemplate();
   const { onCarouselIndexChange } = useCurrentUserTemplate();
+
+  useSendFcmToken();
 
   return (
     <>

--- a/src/store/localStorage/fcmToken.ts
+++ b/src/store/localStorage/fcmToken.ts
@@ -1,8 +1,11 @@
 import { atom } from 'recoil';
 
+import localStorageEffect from './effect';
+
 const fcmTokenState = atom<string | null>({
   key: 'fcmToken',
   default: null,
+  effects: [localStorageEffect<string | null>('fcm_token')],
 });
 
 export default fcmTokenState;

--- a/src/store/push-notification/fcmToken.ts
+++ b/src/store/push-notification/fcmToken.ts
@@ -1,11 +1,8 @@
 import { atom } from 'recoil';
 
-import localStorageEffect from './effect';
-
 const fcmTokenState = atom<string | null>({
   key: 'fcmToken',
   default: null,
-  effects: [localStorageEffect<string | null>('fcm_token')],
 });
 
 export default fcmTokenState;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- resolve #199 

## 🎉 어떻게 해결했나요?

### 앱
`WebView`의 로드가 완료되면 웹 브릿지를 통해 웹에 토큰을 전송
해당 코드 ➡️ https://github.com/depromeet/ahmatda-app/pull/24

### 웹
1. `FcmTokenHandler` 컴포넌트에서 웹뷰 메시지 리스닝 hook을 호출 ➡️ 수신한 토큰을 `fcmToken` atom에 저장
2. `fcmToken && userToken` 이 true면 useMutation을 사용해 서버에 FCM 토큰을 전송

앱 접속 시에만 토큰을 전송하기 위해 `FcmTokenHandler` 컴포넌트를 만들어서 `DefaultLayout` 컴포넌트를 감쌌어요. 
atom을 사용하는 hook의 경우 `RecoilRoot` 하위에 있어야 해서 이렇게 별도의 컴포넌트로 뺐어요 (`_app.page.tsx`에서 hook을 바로 호출할 수 없음!)

2번 로직으로 기존 유저/신규 유저 두 경우 모두를 처리할 수 있어요

- [ ] 안드로이드의 경우 빌드 후 제대로 작동하는지 확인이 필요해요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 