### PR TITLE
[탐색] 추천 카테고리 조회, 추천 템플릿 조회, 바텀시트 내 유저 카테고리 조회, 유저 템플릿 조회 API 부착

### DIFF
--- a/src/components/route-search/CategorySection.tsx
+++ b/src/components/route-search/CategorySection.tsx
@@ -8,7 +8,7 @@ import { Category } from '@/hooks/api/category/type';
 
 interface Props {
   defaultColor?: 'gray';
-  options: Category[];
+  options?: Category[];
   selectedCategory: Category | null;
   onCategoryClick: (selectedCategory: Category) => void;
 }
@@ -16,7 +16,7 @@ interface Props {
 const CategorySection = ({ options, defaultColor, selectedCategory, onCategoryClick }: Props) => {
   return (
     <Wrapper>
-      {options.map((item) => (
+      {options?.map((item) => (
         <Chip
           label={item.name}
           key={item.id}

--- a/src/components/route-search/TemplateAppendBottomSheet.tsx
+++ b/src/components/route-search/TemplateAppendBottomSheet.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
 
 import LabelButton from '../button/LabelButton';
 import IconAdd from '../icon/IconAdd';
@@ -14,6 +15,8 @@ import { Category } from '@/hooks/api/category/type';
 import useGetUserCategories from '@/hooks/api/category/useGetUserCategories';
 import { UserTemplate } from '@/hooks/api/template/type';
 import { get } from '@/lib/api';
+import currentRecCategoryState from '@/store/route-search/currentRecCategory';
+import selectedRecTemplateState from '@/store/route-search/selectedRecTemplate';
 
 type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
 
@@ -23,6 +26,9 @@ const TemplateAppendBottomSheet = ({ isShowing, setToClose }: Props) => {
 
   const { userTemplates, isUserTemplatesLoading, selectedUserTemplate, setSelectedUserTemplate } =
     useUserTemplates(selectedUserCategory);
+
+  const currentRecCategory = useRecoilValue(currentRecCategoryState);
+  const selectedRecTemplate = useRecoilValue(selectedRecTemplateState);
 
   return (
     <LoadingHandler fallback={<>loading...</>} isLoading={isUserCategoriesLoading || isUserTemplatesLoading}>
@@ -41,7 +47,7 @@ const TemplateAppendBottomSheet = ({ isShowing, setToClose }: Props) => {
         <div style={{ marginTop: 8 }}>
           <CategorySection
             defaultColor="gray"
-            options={userCategories}
+            options={userCategories?.concat(currentRecCategory!)}
             selectedCategory={selectedUserCategory}
             onCategoryClick={(clickedCategoryId) => {
               setSelectedUserCategory(clickedCategoryId);
@@ -62,7 +68,9 @@ const TemplateAppendBottomSheet = ({ isShowing, setToClose }: Props) => {
           ))}
           <ListItem newItem>
             <IconAdd />
-            디프만 UT 준비물로 리스트 추가
+            {'{{'}
+            {selectedRecTemplate?.templateName}
+            {'}}'}로 리스트 추가
           </ListItem>
         </List>
       </BottomSheet>

--- a/src/hooks/api/category/useGetRecCategories.ts
+++ b/src/hooks/api/category/useGetRecCategories.ts
@@ -8,35 +8,13 @@ interface Response {
   result: Category[];
 }
 
-// TODO: 실제 API url로 변경
-const getRecCategories = () => get<Response>('');
+const getRecCategories = () => get<Response>('/recommend/category');
 
 const REC_CATEGORIES_QUERY_KEY = 'rec_categories';
 
 const useGetRecCategories = () => {
   const query = useQuery({ queryKey: [REC_CATEGORIES_QUERY_KEY], queryFn: getRecCategories });
-  return { ...query, data: MOCK.result };
+  return { ...query, data: query.data?.result };
 };
 
 export default useGetRecCategories;
-
-const MOCK: {
-  result: Category[];
-  error: null;
-} = {
-  result: [
-    {
-      id: 1,
-      name: '일상',
-      type: 'DAILY',
-      emoji: 'GYM',
-    },
-    {
-      id: 2,
-      name: '운동',
-      type: 'TRAVEL',
-      emoji: 'PLANE',
-    },
-  ],
-  error: null,
-};

--- a/src/hooks/api/template/useGetRecTemplates.ts
+++ b/src/hooks/api/template/useGetRecTemplates.ts
@@ -4,7 +4,7 @@ import { useRecoilValue } from 'recoil';
 import { RecTemplate } from './type';
 
 import { get } from '@/lib/api';
-import { currentRecCategoryInfo } from '@/store/route-search/currentRecCategory';
+import currentRecCategoryState from '@/store/route-search/currentRecCategory';
 
 interface Response {
   result: RecTemplate[];
@@ -15,7 +15,8 @@ const getRecTemplates = (categoryId?: number) => get<Response>(`/recommend/templ
 const REC_TEMPLATES_QUERY_KEY = 'rec_templates';
 
 const useGetRecTemplates = () => {
-  const { currentRecCategoryId } = useRecoilValue(currentRecCategoryInfo);
+  const currentRecCategory = useRecoilValue(currentRecCategoryState);
+  const currentRecCategoryId = currentRecCategory?.id;
   const query = useQuery({
     queryKey: [REC_TEMPLATES_QUERY_KEY, currentRecCategoryId],
     queryFn: () => getRecTemplates(currentRecCategoryId),

--- a/src/hooks/api/template/useGetRecTemplates.ts
+++ b/src/hooks/api/template/useGetRecTemplates.ts
@@ -8,12 +8,9 @@ import { currentRecCategoryInfo } from '@/store/route-search/currentRecCategory'
 
 interface Response {
   result: RecTemplate[];
-  // TODO: 실제 error 타입으로 변경
-  error: any;
 }
 
-// TODO: 실제 API url로 변경
-const getRecTemplates = () => get<Response>('');
+const getRecTemplates = (categoryId?: number) => get<Response>(`/recommend/templates?category=${categoryId}`);
 
 const REC_TEMPLATES_QUERY_KEY = 'rec_templates';
 
@@ -21,55 +18,11 @@ const useGetRecTemplates = () => {
   const { currentRecCategoryId } = useRecoilValue(currentRecCategoryInfo);
   const query = useQuery({
     queryKey: [REC_TEMPLATES_QUERY_KEY, currentRecCategoryId],
-    queryFn: getRecTemplates,
+    queryFn: () => getRecTemplates(currentRecCategoryId),
     enabled: Boolean(currentRecCategoryId),
   });
 
-  return { ...query, data: MOCK.result };
+  return { ...query, data: query.data?.result };
 };
 
 export default useGetRecTemplates;
-
-const MOCK: Response = {
-  result: [
-    {
-      id: 100,
-      templateName: '일상에서 중요한거',
-      categoryId: 1,
-      items: [
-        {
-          id: 1,
-          templateId: 2,
-          categoryId: 1,
-          name: '노트북',
-        },
-        {
-          id: 2,
-          templateId: 2,
-          categoryId: 1,
-          name: '핸드폰',
-        },
-      ],
-    },
-    {
-      id: 101,
-      templateName: '운동에서 중요한거',
-      categoryId: 1,
-      items: [
-        {
-          id: 1,
-          templateId: 2,
-          categoryId: 1,
-          name: '바벨',
-        },
-        {
-          id: 2,
-          templateId: 2,
-          categoryId: 1,
-          name: '꺾이지 않는 마음',
-        },
-      ],
-    },
-  ],
-  error: null,
-};

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -34,7 +34,7 @@ const Template: NextPageWithLayout = () => {
         }}
       />
       <CardsWrapper>
-        {templates.map((templateInfo) => (
+        {templates?.map((templateInfo) => (
           <RecommendationTemplateCard
             key={`rec-template-${templateInfo.id}`}
             data={templateInfo}
@@ -90,6 +90,9 @@ const useRecCategories = () => {
   const query = useGetRecCategories();
 
   useEffect(() => {
+    if (!query.data) {
+      return;
+    }
     setCurrentRecCategory(query.data[0]);
   }, [query.data]);
 

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { NextPageWithLayout } from '../_app.page';
 
@@ -13,11 +13,15 @@ import TemplateAppendBottomSheet from '@/components/route-search/TemplateAppendB
 import useGetRecCategories from '@/hooks/api/category/useGetRecCategories';
 import useGetRecTemplates from '@/hooks/api/template/useGetRecTemplates';
 import currentRecCategoryState from '@/store/route-search/currentRecCategory';
+import selectedRecTemplateState from '@/store/route-search/selectedRecTemplate';
 
 const Template: NextPageWithLayout = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
   const { data: categories, currentRecCategory, setCurrentRecCategory } = useRecCategories();
+
   const { data: templates } = useGetRecTemplates();
+  const setSelectedRecTemplate = useSetRecoilState(selectedRecTemplateState);
 
   return (
     <Wrapper>
@@ -40,6 +44,7 @@ const Template: NextPageWithLayout = () => {
             data={templateInfo}
             submitBtnTitle="내 리스트에 추가하기"
             onSubmit={() => {
+              setSelectedRecTemplate(templateInfo);
               setIsBottomSheetOpen(true);
             }}
           />
@@ -90,10 +95,9 @@ const useRecCategories = () => {
   const query = useGetRecCategories();
 
   useEffect(() => {
-    if (!query.data) {
-      return;
+    if (query.data && currentRecCategory === null) {
+      setCurrentRecCategory(query.data[0]);
     }
-    setCurrentRecCategory(query.data[0]);
   }, [query.data]);
 
   return { ...query, currentRecCategory, setCurrentRecCategory };

--- a/src/store/route-search/currentRecCategory.ts
+++ b/src/store/route-search/currentRecCategory.ts
@@ -1,4 +1,4 @@
-import { atom, selector } from 'recoil';
+import { atom } from 'recoil';
 
 import { Category } from '@/hooks/api/category/type';
 
@@ -8,16 +8,3 @@ const currentRecCategoryState = atom<Category | null>({
 });
 
 export default currentRecCategoryState;
-
-export const currentRecCategoryInfo = selector({
-  key: 'currentRecCategoryInfo',
-  get: ({ get }) => {
-    const category = get(currentRecCategoryState);
-    const currentRecCategoryName = category?.name;
-    const currentRecCategoryId = category?.id;
-    return {
-      currentRecCategoryName,
-      currentRecCategoryId,
-    };
-  },
-});


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- resolve #176 
- resolve #200 
- mock 데이터를 실제 API로 대체했어요

## 🎉 어떻게 해결했나요?
유저 카테고리 조회, 유저 템플릿 조회 API가 쓰이는 곳이 두 군데에요
1. 홈 탭
2. 탐색 탭의  `내 리스트에 추가하기` 바텀 시트

그래서 혜성님이 작성한 `useGetUserCategories`, `useGetUserTemplate`를 사용하려고 했어요. 그런데`useGetUserTemplate`이 `currentCategory`라는 atom 값에 의존하고 있어서! 우선은 `TemplateAppendBottomSheet.tsx` 하단에 `useGetUserTemplates`라는 hook을 작성했어요

`hooks/api` 폴더 구조가 templates, category 이렇게 나뉘어져 있다보니 어느 폴더에 넣어야할 지 애매한 hook들이 생기네욤 


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 