### PR TITLE
[탐색] 바텀시트 완료 시 해당 추천템플릿의 체크 상태 리셋, 스피너 적용

### DIFF
--- a/src/components/route-search/RecommendationTemplateCard.test.tsx
+++ b/src/components/route-search/RecommendationTemplateCard.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 
 import RecommendationTemplateCard from './RecommendationTemplateCard';
 
@@ -7,7 +8,11 @@ import customRender from '@/test/customRender';
 
 describe('추천 템플릿 카드', () => {
   it('추천 템플릿 카드가 올바르게 작동한다.', () => {
-    customRender(<RecommendationTemplateCard data={MOCK} />);
+    customRender(
+      <RecoilRoot>
+        <RecommendationTemplateCard data={MOCK} isRefetchingTemplateData={false} />
+      </RecoilRoot>,
+    );
     const checkAllBtn = screen.getByLabelText('전체 선택');
     const checkBtns = screen.getAllByTestId('single-check-btn');
 

--- a/src/components/route-search/RecommendationTemplateCard.tsx
+++ b/src/components/route-search/RecommendationTemplateCard.tsx
@@ -1,6 +1,6 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import ContainedButton from '../button/ContainedButton';
 import Checkbox from '../checkbox/Checkbox';
@@ -14,9 +14,10 @@ export interface Props {
   data: RecTemplate;
   submitBtnTitle?: string;
   onSubmit?: VoidFunction;
+  isRefetchingTemplateData: boolean;
 }
 
-const RecommendationTemplateCard = ({ data, submitBtnTitle, onSubmit }: Props) => {
+const RecommendationTemplateCard = ({ data, submitBtnTitle, onSubmit, isRefetchingTemplateData }: Props) => {
   const { id: templateId, templateName, items } = data;
   const [checkedId, setCheckedId] = useState(new Set());
 
@@ -45,7 +46,11 @@ const RecommendationTemplateCard = ({ data, submitBtnTitle, onSubmit }: Props) =
     return items.filter(({ id }) => checkedId.has(id)).map(({ name }) => name);
   };
 
-  const setSelectedTemplate = useSetRecoilState(selectedRecTemplateState);
+  const resetCheckedId = () => {
+    setCheckedId(new Set());
+  };
+
+  const [selectedTemplate, setSelectedTemplate] = useRecoilState(selectedRecTemplateState);
   const setSelectedItems = useSetRecoilState(selectedRecItemsState);
 
   const onSubmitBtnClick = () => {
@@ -56,6 +61,12 @@ const RecommendationTemplateCard = ({ data, submitBtnTitle, onSubmit }: Props) =
     const checkedItemsNames = computeCheckedItemsNames();
     setSelectedItems(checkedItemsNames);
   };
+
+  useEffect(() => {
+    if (selectedTemplate?.id === templateId) {
+      resetCheckedId();
+    }
+  }, [isRefetchingTemplateData]);
 
   return (
     <Wrapper>

--- a/src/components/route-search/TemplateAppendBottomSheet.tsx
+++ b/src/components/route-search/TemplateAppendBottomSheet.tsx
@@ -6,6 +6,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import LabelButton from '../button/LabelButton';
 import IconAdd from '../icon/IconAdd';
 import LoadingHandler from '../loading/LoadingHandler';
+import Spinner from '../loading/Spinner';
 import AppBar from '../navigation/AppBar';
 import BottomSheet from '../portal/BottomSheet';
 
@@ -69,7 +70,7 @@ const TemplateAppendBottomSheet = ({ isShowing, setToClose }: Props) => {
         }
         onClickBackButton={onCloseBottomSheet}
       />
-      <LoadingHandler fallback={<>loading...</>} isLoading={isUserCategoriesLoading || isUserTemplatesLoading}>
+      <LoadingHandler fallback={<Spinner />} isLoading={isUserCategoriesLoading || isUserTemplatesLoading}>
         <div style={{ marginTop: 8 }}>
           <CategorySection
             defaultColor="gray"

--- a/src/hooks/api/template/useAppendToMyTemplate.ts
+++ b/src/hooks/api/template/useAppendToMyTemplate.ts
@@ -5,6 +5,7 @@ import { Category } from '../category/type';
 import { USER_CATEGORY_QUERY_KEY } from '../category/useGetUserCategories';
 
 import { RecTemplate, UserTemplate } from './type';
+import { REC_TEMPLATES_QUERY_KEY } from './useGetRecTemplates';
 
 import { post } from '@/lib/api';
 import selectedCategoryState from '@/store/route-search/bottomSheet/selectedCategory';
@@ -35,6 +36,7 @@ const useAppendToMyTemplate = () => {
   const appendToMyTemplateMutation = useMutation(appendToMyTemplate, {
     onSuccess: () => {
       queryClient.invalidateQueries([USER_CATEGORY_QUERY_KEY]);
+      queryClient.refetchQueries([REC_TEMPLATES_QUERY_KEY]);
     },
   });
 

--- a/src/hooks/api/template/useGetRecTemplates.ts
+++ b/src/hooks/api/template/useGetRecTemplates.ts
@@ -12,7 +12,7 @@ interface Response {
 
 const getRecTemplates = (categoryId?: number) => get<Response>(`/recommend/templates?category=${categoryId}`);
 
-const REC_TEMPLATES_QUERY_KEY = 'rec_templates';
+export const REC_TEMPLATES_QUERY_KEY = 'rec_templates';
 
 const useGetRecTemplates = () => {
   const currentRecCategory = useRecoilValue(currentRecCategoryState);

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -4,6 +4,8 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { NextPageWithLayout } from '../_app.page';
 
+import FixedSpinner from '@/components/loading/FixedSpinner';
+import LoadingHandler from '@/components/loading/LoadingHandler';
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-search/CategorySection';
@@ -20,45 +22,47 @@ const Template: NextPageWithLayout = () => {
 
   const { data: categories, currentRecCategory, setCurrentRecCategory } = useRecCategories();
 
-  const { data: templates, isRefetching: isRefetchingRecTemplates } = useGetRecTemplates();
+  const { data: templates, isRefetching: isRefetchingRecTemplates, isLoading } = useGetRecTemplates();
   const setSelectedRecTemplate = useSetRecoilState(selectedRecTemplateState);
 
   return (
-    <Wrapper>
-      <Title>
-        상황에 맞는
-        <br />
-        소지품을 추천해 드릴게요
-      </Title>
-      <CategorySection
-        options={categories}
-        selectedCategory={currentRecCategory}
-        onCategoryClick={(clickedCategory) => {
-          setCurrentRecCategory(clickedCategory);
-        }}
-      />
-      <CardsWrapper>
-        {templates?.map((templateInfo) => (
-          <RecommendationTemplateCard
-            key={`rec-template-${templateInfo.id}`}
-            data={templateInfo}
-            isRefetchingTemplateData={isRefetchingRecTemplates}
-            submitBtnTitle="내 리스트에 추가하기"
-            onSubmit={() => {
-              setSelectedRecTemplate(templateInfo);
-              setIsBottomSheetOpen(true);
-            }}
-          />
-        ))}
-      </CardsWrapper>
-      <ListRequestSection />
-      <TemplateAppendBottomSheet
-        isShowing={isBottomSheetOpen}
-        setToClose={() => {
-          setIsBottomSheetOpen(false);
-        }}
-      />
-    </Wrapper>
+    <LoadingHandler isLoading={isLoading} fallback={<FixedSpinner />}>
+      <Wrapper>
+        <Title>
+          상황에 맞는
+          <br />
+          소지품을 추천해 드릴게요
+        </Title>
+        <CategorySection
+          options={categories}
+          selectedCategory={currentRecCategory}
+          onCategoryClick={(clickedCategory) => {
+            setCurrentRecCategory(clickedCategory);
+          }}
+        />
+        <CardsWrapper>
+          {templates?.map((templateInfo) => (
+            <RecommendationTemplateCard
+              key={`rec-template-${templateInfo.id}`}
+              data={templateInfo}
+              isRefetchingTemplateData={isRefetchingRecTemplates}
+              submitBtnTitle="내 리스트에 추가하기"
+              onSubmit={() => {
+                setSelectedRecTemplate(templateInfo);
+                setIsBottomSheetOpen(true);
+              }}
+            />
+          ))}
+        </CardsWrapper>
+        <ListRequestSection />
+        <TemplateAppendBottomSheet
+          isShowing={isBottomSheetOpen}
+          setToClose={() => {
+            setIsBottomSheetOpen(false);
+          }}
+        />
+      </Wrapper>
+    </LoadingHandler>
   );
 };
 

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -20,7 +20,7 @@ const Template: NextPageWithLayout = () => {
 
   const { data: categories, currentRecCategory, setCurrentRecCategory } = useRecCategories();
 
-  const { data: templates } = useGetRecTemplates();
+  const { data: templates, isRefetching: isRefetchingRecTemplates } = useGetRecTemplates();
   const setSelectedRecTemplate = useSetRecoilState(selectedRecTemplateState);
 
   return (
@@ -42,6 +42,7 @@ const Template: NextPageWithLayout = () => {
           <RecommendationTemplateCard
             key={`rec-template-${templateInfo.id}`}
             data={templateInfo}
+            isRefetchingTemplateData={isRefetchingRecTemplates}
             submitBtnTitle="내 리스트에 추가하기"
             onSubmit={() => {
               setSelectedRecTemplate(templateInfo);


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- resolve #218 
- 로딩 스피너 적용

## 🎉 어떻게 해결했나요?
- 완료 시 `refetchQueries`를 호출해요. `isRefetching` 값을 이용해 `RecommendationTemplateCard`에게 바텀시트가 완료되었다는 걸 알려요. `index.page.tsx`에서 props로 전달 받은 `isRefetching` 값이 변경되고, 템플릿 카드의 id값이 `selectedTemplate.id`와 일치할 경우 체크 상태를 리셋해요. 
- 스피너 위치를 가운데로 정렬해야 할 것 같아요 ➡️ 이건 다음 issue로
  <img width="309" alt="image" src="https://user-images.githubusercontent.com/87167786/209842940-6b4db4b3-47b0-40a6-96fb-a61c5a74d98a.png">

### 📚 Attachment (Option)
https://github.com/TanStack/query/discussions/2468
 