### PR TITLE
카테고리 추가, 설정 바텀시트 그래픽 종류 단축

### DIFF
--- a/src/components/route-home/category/CategoryIconRadioFieldset.tsx
+++ b/src/components/route-home/category/CategoryIconRadioFieldset.tsx
@@ -1,9 +1,24 @@
 import { Dispatch, FC, Fragment, MouseEvent, SetStateAction, useId } from 'react';
 import styled from '@emotion/styled';
 
-import { Graphic as GraphicType, graphics } from '../../graphic/type';
+import { Graphic as GraphicType } from '../../graphic/type';
 
 import Graphic from '@/components/graphic/Graphic';
+
+const categoryGraphics: GraphicType[] = [
+  'WORK',
+  'SCHOOL',
+  'FRIENDS',
+  'CAMERA',
+  'TUBE',
+  'BUS',
+  'PLANE',
+  'RUN',
+  'GYM',
+  'BOWLING',
+  'SWIM',
+  'ETC',
+];
 
 interface Props {
   currentValue: GraphicType | null;
@@ -21,7 +36,7 @@ const CategoryIconRadioGroup: FC<Props> = ({ currentValue, setCurrentValue }) =>
     <fieldset>
       <Legend>아이콘 *</Legend>
       <Wrapper>
-        {graphics.map((type) => (
+        {categoryGraphics.map((type) => (
           <Fragment key={type}>
             <HidedInput type="radio" id={`${type}-${id}`} value={type} onClick={onClick} />
             <GraphicLabel htmlFor={`${type}-${id}`}>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 카테고리 추가, 설정 바텀시트에서 모든 종류의 그래픽이 그려짐

## 🎉 어떻게 해결했나요?
- 모든 그래픽을 그리는 것이 아닌, 사용하는 곳에서 배열을 선언하도록 변경

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

<img width="393" alt="스크린샷 2022-12-29 오후 5 33 52" src="https://user-images.githubusercontent.com/26461307/209925224-cbb4fe6b-e60f-4063-a0bd-2c0d54465822.png">
