### PR TITLE
소지품 수정, 챙김 API

### DIFF
--- a/src/components/route-home/CardItem.tsx
+++ b/src/components/route-home/CardItem.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { ChangeEventHandler, useId } from 'react';
 import dynamic from 'next/dynamic';
 import { css, Theme } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -6,6 +6,7 @@ import styled from '@emotion/styled';
 import IconCardItemCheck from './IconCardItemCheck';
 
 import { UserItem } from '@/hooks/api/template/type';
+import useCardItemMutation from '@/hooks/api/template/useCardItemMutation';
 import useToggle from '@/hooks/common/useToggle';
 
 const CardItemSettingBottomSheet = dynamic(() => import('./CardItemSettingBottomSheet'));
@@ -19,25 +20,24 @@ interface Props {
 
 const CardItem = ({ name, take, important, itemId }: Props) => {
   const id = useId();
-  // TODO: API 대응
-  const [isCurrentChecked, _, toggleCurrentChecked] = useToggle(take);
 
   const [isCardItemSettingShowing, __, toggleIsCardItemSettingShowing] = useToggle(false);
 
+  const { editCardItemMutation } = useCardItemMutation();
+
+  const onChangeTakeCheckbox: ChangeEventHandler<HTMLInputElement> = (e) => {
+    editCardItemMutation.mutate({ itemId, modifiedItemName: name, important, isTake: e.target.checked });
+  };
+
   return (
     <>
-      <Wrapper isChecked={isCurrentChecked} isImportant={important}>
-        <HidedInput id={id} type="checkbox" checked={isCurrentChecked} onChange={toggleCurrentChecked} />
+      <Wrapper isChecked={take} isImportant={important}>
+        <HidedInput id={id} type="checkbox" checked={take} onChange={onChangeTakeCheckbox} />
         <IconLabel htmlFor={id}>
-          <IconCardItemCheck isChecked={isCurrentChecked} isImportant={important} />
+          <IconCardItemCheck isChecked={take} isImportant={important} />
         </IconLabel>
 
-        <NameButton
-          type="button"
-          onClick={toggleIsCardItemSettingShowing}
-          isChecked={isCurrentChecked}
-          isImportant={important}
-        >
+        <NameButton type="button" onClick={toggleIsCardItemSettingShowing} isChecked={take} isImportant={important}>
           {name}
         </NameButton>
       </Wrapper>

--- a/src/components/route-home/CardItem.tsx
+++ b/src/components/route-home/CardItem.tsx
@@ -23,10 +23,10 @@ const CardItem = ({ name, take, important, itemId }: Props) => {
 
   const [isCardItemSettingShowing, __, toggleIsCardItemSettingShowing] = useToggle(false);
 
-  const { editCardItemMutation } = useCardItemMutation();
+  const { editCardItemTakeMutation } = useCardItemMutation();
 
   const onChangeTakeCheckbox: ChangeEventHandler<HTMLInputElement> = (e) => {
-    editCardItemMutation.mutate({ itemId, modifiedItemName: name, important, isTake: e.target.checked });
+    editCardItemTakeMutation.mutate({ itemId, isTake: e.target.checked });
   };
 
   return (
@@ -46,7 +46,6 @@ const CardItem = ({ name, take, important, itemId }: Props) => {
         itemId={itemId}
         name={name}
         important={important}
-        take={take}
         setToClose={toggleIsCardItemSettingShowing}
         isShowing={isCardItemSettingShowing}
       />

--- a/src/components/route-home/CardItem.tsx
+++ b/src/components/route-home/CardItem.tsx
@@ -46,6 +46,7 @@ const CardItem = ({ name, take, important, itemId }: Props) => {
         itemId={itemId}
         name={name}
         important={important}
+        take={take}
         setToClose={toggleIsCardItemSettingShowing}
         isShowing={isCardItemSettingShowing}
       />

--- a/src/components/route-home/CardItemSettingBottomSheet.tsx
+++ b/src/components/route-home/CardItemSettingBottomSheet.tsx
@@ -19,10 +19,9 @@ interface Props extends BottomSheetProps {
   itemId: UserItem['id'];
   name: UserItem['name'];
   important: UserItem['important'];
-  take: UserItem['take'];
 }
 
-const TemplateItemSettingBottomSheet = ({ isShowing, setToClose, itemId, name, important, take }: Props) => {
+const TemplateItemSettingBottomSheet = ({ isShowing, setToClose, itemId, name, important }: Props) => {
   const {
     value: itemName,
     onChange: onChangeItemName,
@@ -38,7 +37,7 @@ const TemplateItemSettingBottomSheet = ({ isShowing, setToClose, itemId, name, i
   const { editCardItemMutation, deleteCardItemMutation } = useCardItemMutation();
 
   const handleTemplateItemSettingComplete = () => {
-    editCardItemMutation.mutate({ itemId, modifiedItemName: debouncedItemName, isTake: take, important: isImportant });
+    editCardItemMutation.mutate({ itemId, modifiedItemName: debouncedItemName, important: isImportant });
     setToClose();
   };
 

--- a/src/components/route-home/CardItemSettingBottomSheet.tsx
+++ b/src/components/route-home/CardItemSettingBottomSheet.tsx
@@ -11,6 +11,7 @@ import ToggleSwitch from '../toggle/ToggleSwitch';
 import { UserItem } from '@/hooks/api/template/type';
 import useCardItemMutation from '@/hooks/api/template/useCardItemMutation';
 import useInput from '@/hooks/common/useInput';
+import useToggle from '@/hooks/common/useToggle';
 
 type BottomSheetProps = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
 
@@ -18,23 +19,26 @@ interface Props extends BottomSheetProps {
   itemId: UserItem['id'];
   name: UserItem['name'];
   important: UserItem['important'];
+  take: UserItem['take'];
 }
 
-const TemplateItemSettingBottomSheet = ({ isShowing, setToClose, itemId, name, important }: Props) => {
+const TemplateItemSettingBottomSheet = ({ isShowing, setToClose, itemId, name, important, take }: Props) => {
   const {
     value: itemName,
     onChange: onChangeItemName,
     debouncedValue: debouncedItemName,
   } = useInput({ initialValue: name, useDebounce: true });
 
+  const [isImportant, _, toggleIsImportant] = useToggle(important);
+
   const [isDialogShowing, setIsDialogShowing] = useState(false);
 
   const isSubmitDisabled = debouncedItemName.length === 0 || debouncedItemName.length >= 30;
 
-  const { deleteCardItemMutation } = useCardItemMutation();
+  const { editCardItemMutation, deleteCardItemMutation } = useCardItemMutation();
 
   const handleTemplateItemSettingComplete = () => {
-    // TODO: 소지품 설정 완료 시 실행할 로직 추가
+    editCardItemMutation.mutate({ itemId, modifiedItemName: debouncedItemName, isTake: take, important: isImportant });
     setToClose();
   };
 
@@ -71,7 +75,7 @@ const TemplateItemSettingBottomSheet = ({ isShowing, setToClose, itemId, name, i
       <SettingOptionList>
         <Option>
           <span>중요 소지품</span>
-          <ToggleSwitch defaultChecked={important} />
+          <ToggleSwitch checked={isImportant} onChange={toggleIsImportant} />
         </Option>
         <Option
           isDeleteOption

--- a/src/components/route-home/IconCardItemCheck.tsx
+++ b/src/components/route-home/IconCardItemCheck.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import { useTheme } from '@emotion/react';
 import { AnimatePresence, m, Variants } from 'framer-motion';
 
@@ -56,11 +56,10 @@ const IconCardItemCheck: FC<Props> = ({ isChecked, isImportant }) => {
           animate="animate"
           exit="exit"
         >
-          <m.path
+          <path
             d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z"
             fill="white"
-            variants={opacityVariants}
-            custom={isImportant ? 0.5 : 1}
+            style={{ opacity: isImportant ? 0.5 : 1, transition: 'opacity 0.3s' }}
           />
           <m.path
             d="M10.7 10.7002L13.3861 13.3863"

--- a/src/hooks/api/template/useCardItemMutation.ts
+++ b/src/hooks/api/template/useCardItemMutation.ts
@@ -20,11 +20,19 @@ interface createCardItemRequest extends createCardItemProps {
 interface editCardItemProps {
   itemId: number;
   modifiedItemName: string;
-  isTake: boolean;
   important: boolean;
 }
 
 interface editCardItemRequest extends editCardItemProps {
+  templateId: number;
+}
+
+interface editCardItemTakeProps {
+  itemId: number;
+  isTake: boolean;
+}
+
+interface editCardItemTakeRequest extends editCardItemTakeProps {
   templateId: number;
 }
 
@@ -78,6 +86,22 @@ const useCardItemMutation = () => {
 
       return patch('/template/item', requestData);
     },
+    onSuccess: () => {
+      invalidateCurrentUserTemplate();
+    },
+  });
+
+  const editCardItemTakeMutation = useMutation({
+    mutationFn: (toggledCardItem: editCardItemTakeProps) => {
+      if (!currentTemplate) throw new Error('');
+
+      const requestData: editCardItemTakeRequest = {
+        ...toggledCardItem,
+        templateId: currentTemplate.id,
+      };
+
+      return patch('/template/item', requestData);
+    },
     onMutate: async (editedCardItem) => {
       await queryClient.cancelQueries([USER_TEMPLATE_QUERY_KEY, currentCategory?.id]);
 
@@ -92,9 +116,7 @@ const useCardItemMutation = () => {
             if (item.id === editedCardItem.itemId)
               return {
                 ...item,
-                name: editedCardItem.modifiedItemName,
                 take: editedCardItem.isTake,
-                important: editedCardItem.important,
               };
             return item;
           });
@@ -107,7 +129,6 @@ const useCardItemMutation = () => {
 
       return prevUserTemplate;
     },
-    onSettled: () => invalidateCurrentUserTemplate(),
   });
 
   const deleteCardItemMutation = useMutation(
@@ -128,7 +149,7 @@ const useCardItemMutation = () => {
     },
   );
 
-  return { createCardItemMutation, editCardItemMutation, deleteCardItemMutation };
+  return { createCardItemMutation, editCardItemMutation, editCardItemTakeMutation, deleteCardItemMutation };
 };
 
 export default useCardItemMutation;

--- a/src/hooks/api/template/useCardItemMutation.ts
+++ b/src/hooks/api/template/useCardItemMutation.ts
@@ -1,9 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
-import { USER_TEMPLATE_QUERY_KEY } from './useGetUserTemplate';
+import { Response as UserTemplateResponse, USER_TEMPLATE_QUERY_KEY } from './useGetUserTemplate';
 
-import { del, post } from '@/lib/api';
+import { del, patch, post } from '@/lib/api';
 import currentCategoryState from '@/store/route-home/currentCategory';
 import currentUserTemplateState from '@/store/route-home/currentUserTemplate';
 
@@ -14,6 +14,17 @@ interface createCardItemProps {
 
 interface createCardItemRequest extends createCardItemProps {
   categoryId: number;
+  templateId: number;
+}
+
+interface editCardItemProps {
+  itemId: number;
+  modifiedItemName: string;
+  isTake: boolean;
+  important: boolean;
+}
+
+interface editCardItemRequest extends editCardItemProps {
   templateId: number;
 }
 
@@ -56,6 +67,49 @@ const useCardItemMutation = () => {
     },
   );
 
+  const editCardItemMutation = useMutation({
+    mutationFn: (editedCardItem: editCardItemProps) => {
+      if (!currentTemplate) throw new Error('');
+
+      const requestData: editCardItemRequest = {
+        ...editedCardItem,
+        templateId: currentTemplate.id,
+      };
+
+      return patch('/template/item', requestData);
+    },
+    onMutate: async (editedCardItem) => {
+      await queryClient.cancelQueries([USER_TEMPLATE_QUERY_KEY, currentCategory?.id]);
+
+      const prevUserTemplate = queryClient.getQueryData([USER_TEMPLATE_QUERY_KEY, currentCategory?.id]);
+
+      queryClient.setQueryData<UserTemplateResponse>([USER_TEMPLATE_QUERY_KEY, currentCategory?.id], (old) => {
+        if (typeof old === 'undefined') return undefined;
+
+        const eachTemplates = old.result;
+        const updatedTemplates = eachTemplates.map((template) => {
+          const updatedItems = template.items.map((item) => {
+            if (item.id === editedCardItem.itemId)
+              return {
+                ...item,
+                name: editedCardItem.modifiedItemName,
+                take: editedCardItem.isTake,
+                important: editedCardItem.important,
+              };
+            return item;
+          });
+
+          return { ...template, items: updatedItems };
+        });
+
+        return { result: [...updatedTemplates] };
+      });
+
+      return prevUserTemplate;
+    },
+    onSettled: () => invalidateCurrentUserTemplate(),
+  });
+
   const deleteCardItemMutation = useMutation(
     ({ itemId }: deleteCardItemProps) => {
       if (!currentTemplate) throw new Error('');
@@ -74,7 +128,7 @@ const useCardItemMutation = () => {
     },
   );
 
-  return { createCardItemMutation, deleteCardItemMutation };
+  return { createCardItemMutation, editCardItemMutation, deleteCardItemMutation };
 };
 
 export default useCardItemMutation;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

> 현재 API 수정이 이루어지지 않은 상태입니다

## 🤔 해결하려는 문제가 무엇인가요?
- close #165 close #166

## 🎉 어떻게 해결했나요?

<details>

<summary>
draft 중일 때 내용
</summary>

- mutation을 이용하며, 낙관적 업데이트를 하도록 했어요
  https://tanstack.com/query/v4/docs/react/guides/optimistic-updates?from=reactQueryV3&original=https%3A%2F%2Freact-query-v3.tanstack.com%2Fguides%2Foptimistic-updates
  
  허나 사용자 템플릿과 함께 아이템을 조회하다 보니 (제가 깔끔하게 적는 능력이 부족하다보니) 레거시가 된 거 같기도 해요

  그래서 일반적인 mutation 이후 invalidate하는 게 좋을지 ... 고민이 됨니다

</details>



- API 스펙에 맞게 `사용자 카드 아이템 챙김 수정`, `사용자 카드 아이템 이름, 중요 여부 수정`으로 나누어 각각 `editCardItemTakeMutation`, `editCardItemMutation`으로 개발했어요

  - `editCardItemTakeMutation`의 경우 낙관적으로 업데이트해요
  - `editCardItemMutation`은 업데이트 후 invalidate해요

  - invalidate 시에 조회 순서가 보장이 되지 않더라구요 ! 따로 백엔드 분들께 말씀드려 정렬 기준을 세우던지 해야할거가타요


---
```tsx
interface editCardItemProps {
  itemId: number;
  modifiedItemName: string;
  important: boolean;
}

interface editCardItemRequest extends editCardItemProps {
  templateId: number;
}
```
> mutationProps와 mutationRequest 타입을 정의하는 과정에서 반복되는 부분이 많아 타입을 확장해서 쓸 수 있게 할까 했는데 그러면 더 알아보기 힘들거나 변경에 대응하기 어려울 것도 같으면서 ... 그래서 일단 그냥 다 적었슴니다

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 