### PR TITLE
추천 소지품 조회, 추가, 삭제

### DIFF
--- a/@types/common.d.ts
+++ b/@types/common.d.ts
@@ -1,1 +1,5 @@
 type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+interface ApiResponse<T> {
+  result: T;
+}

--- a/src/components/route-home/RecommendSection.tsx
+++ b/src/components/route-home/RecommendSection.tsx
@@ -2,9 +2,11 @@ import { useRef } from 'react';
 import styled from '@emotion/styled';
 import { AnimatePresence, DragHandlers, m, useAnimationControls } from 'framer-motion';
 
+import LoadingHandler from '../loading/LoadingHandler';
 import Tag from '../tag/Tag';
 
 import { defaultEasing } from '@/constants/motions';
+import useGetRecommendItem from '@/hooks/api/recommend-item/useGetRecommendItem';
 import useToggle from '@/hooks/common/useToggle';
 import useDidUpdate from '@/hooks/life-cycle/useDidUpdate';
 
@@ -12,6 +14,8 @@ const HIDE_BOTTOM_POS = 84;
 
 const RecommendSection = () => {
   const { onDragStart, onDragEnd, onClickToggleButton, animationControls } = useSectionVisible();
+
+  const { data, isLoading } = useGetRecommendItem();
 
   // TODO: API 부착 이후 대응
   const testFn = () => {
@@ -34,12 +38,15 @@ const RecommendSection = () => {
           <DragHandlerSpan />
         </DragHandlerButton>
 
-        <SuggestionText>날씨가 부쩍 추워졌어요. 이런 건 어때요?</SuggestionText>
+        <LoadingHandler isLoading={isLoading} fallback={undefined}>
+          <SuggestionText>이런 건 어때요?</SuggestionText>
 
-        <ItemWrapper>
-          <Tag value="핫팩" onClickCancel={testFn} />
-          <Tag value="겉옷" onClickCancel={testFn} />
-        </ItemWrapper>
+          <ItemWrapper>
+            {data?.items.map((item) => (
+              <StyledTag key={item} value={item} onClickCancel={testFn} />
+            ))}
+          </ItemWrapper>
+        </LoadingHandler>
       </Wrapper>
     </AnimatePresence>
   );
@@ -94,7 +101,20 @@ const SuggestionText = styled.p({ marginBottom: '8px' }, ({ theme }) => ({
   color: theme.colors.gray4,
 }));
 
-const ItemWrapper = styled.div({ display: 'flex', gap: '8px', marginBottom: '22px' });
+const ItemWrapper = styled.div({
+  display: 'flex',
+  flexShrink: 0,
+  gap: '8px',
+  marginBottom: '22px',
+  flexWrap: 'nowrap',
+  overflowX: 'scroll',
+  overflowY: 'hidden',
+});
+
+const StyledTag = styled(Tag)({
+  flex: '0 0 auto',
+  height: '38px',
+});
 
 const useSectionVisible = () => {
   const animationControls = useAnimationControls();

--- a/src/components/route-home/RecommendSection.tsx
+++ b/src/components/route-home/RecommendSection.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { AnimatePresence, DragHandlers, m, useAnimationControls } from 'framer-motion';
 
@@ -15,13 +15,7 @@ const HIDE_BOTTOM_POS = 84;
 const RecommendSection = () => {
   const { onDragStart, onDragEnd, onClickToggleButton, animationControls } = useSectionVisible();
 
-  const { data, isLoading } = useGetRecommendItem();
-
-  // TODO: API 부착 이후 대응
-  const testFn = () => {
-    // eslint-disable-next-line no-console
-    console.log('clicked');
-  };
+  const { items, isLoading, onClickDelete } = useRecommendItem();
 
   return (
     <AnimatePresence mode="wait">
@@ -42,8 +36,8 @@ const RecommendSection = () => {
           <SuggestionText>이런 건 어때요?</SuggestionText>
 
           <ItemWrapper>
-            {data?.items.map((item) => (
-              <StyledTag key={item} value={item} onClickCancel={testFn} />
+            {items.map((item) => (
+              <StyledTag key={item.id} value={item.name} onClickCancel={onClickDelete(item.id)} />
             ))}
           </ItemWrapper>
         </LoadingHandler>
@@ -164,4 +158,26 @@ const visibleMotion = {
 const hideMotion = {
   y: HIDE_BOTTOM_POS,
   transition: { duration: 0.5, ease: defaultEasing },
+};
+
+interface RecommendItem {
+  id: number;
+  name: string;
+}
+
+const useRecommendItem = () => {
+  const { data, isLoading } = useGetRecommendItem();
+
+  const [items, setItems] = useState<RecommendItem[]>([]);
+
+  useEffect(() => {
+    if (!data) return;
+    setItems(data.items.map((item, index) => ({ id: index, name: item })));
+  }, [data]);
+
+  const onClickDelete = (itemId: RecommendItem['id']) => () => {
+    setItems((prev) => prev.filter((item) => item.id !== itemId));
+  };
+
+  return { items, isLoading, onClickDelete };
 };

--- a/src/components/tag/Tag.tsx
+++ b/src/components/tag/Tag.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, forwardRef, Ref } from 'react';
+import { ComponentPropsWithoutRef, forwardRef, MouseEventHandler, Ref } from 'react';
 import styled from '@emotion/styled';
 
 import IconCancelSmall from '../icon/IconCancelSmall';
@@ -7,7 +7,7 @@ type ButtonPropsWithoutChildrenAndRef = Omit<ComponentPropsWithoutRef<'button'>,
 
 interface Props extends ButtonPropsWithoutChildrenAndRef {
   value: string;
-  onClickCancel?: VoidFunction;
+  onClickCancel?: MouseEventHandler<SVGSVGElement>;
 }
 
 const Tag = forwardRef(function Tag(

--- a/src/hooks/api/recommend-item/useGetRecommendItem.tsx
+++ b/src/hooks/api/recommend-item/useGetRecommendItem.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
+import { Category } from '../category/type';
+
+import { get } from '@/lib/api';
+import currentCategoryState from '@/store/route-home/currentCategory';
+
+interface Response {
+  result: {
+    items: string[];
+  };
+}
+
+const HOME_RECOMMEND_ITEM_QUERY_KEY = 'home_recommend_item';
+
+const getRecommendItem = (categoryId: Category['id']) => get<Response>(`/recommend/items?category=${categoryId}`);
+
+const useGetRecommendItem = () => {
+  const currentCategory = useRecoilValue(currentCategoryState);
+
+  const query = useQuery({
+    queryKey: [HOME_RECOMMEND_ITEM_QUERY_KEY, currentCategory?.id],
+    queryFn: () => getRecommendItem((currentCategory as Category).id),
+    enabled: Boolean(currentCategory),
+  });
+
+  return { ...query, data: query.data?.result };
+};
+
+export default useGetRecommendItem;

--- a/src/hooks/api/recommend-item/useGetRecommendItem.tsx
+++ b/src/hooks/api/recommend-item/useGetRecommendItem.tsx
@@ -7,14 +7,13 @@ import { get } from '@/lib/api';
 import currentCategoryState from '@/store/route-home/currentCategory';
 
 interface Response {
-  result: {
-    items: string[];
-  };
+  items: string[];
 }
 
 const HOME_RECOMMEND_ITEM_QUERY_KEY = 'home_recommend_item';
 
-const getRecommendItem = (categoryId: Category['id']) => get<Response>(`/recommend/items?category=${categoryId}`);
+const getRecommendItem = (categoryId: Category['id']) =>
+  get<ApiResponse<Response>>(`/recommend/items?category=${categoryId}`);
 
 const useGetRecommendItem = () => {
   const currentCategory = useRecoilValue(currentCategoryState);


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #186 close #209

## 🎉 어떻게 해결했나요?
- 추천 소지품을 조회하는 `hooks/api/recommend-item/useGetRecommendItem`을 개발했어요
  - 추천 탭과 혼선이 있을 지 걱정이에요 🤔 

- 추천 소지품 조회 값을 이용해 재가공하고, 추가, 삭제 로직을 담당하는 훅을 `RecommendSection`에 위치시켰어요
  - 조회된 값을 이용해 재가공을 하는 경우에 저는 이렇게 하곤 했는데 더 좋은 방법이 있으면 추천 부탁드려용
  - 추가시 현재 보고 있는 카테고리, 템플릿에 추가되도록 했어요
  - 삭제 이후에 다시 조회한다면 (다른 페이지에 갓다오거나) 똑같은 추천 소지품을 보여주기 때문에 이쪽도 API가 추가되면 좋을 거 같아요 @sungmin69355 물론 배포 이후에 해도 좋아용
  
  https://user-images.githubusercontent.com/26461307/210040645-b6a59812-1fe4-468f-8f12-26d7a93c29ca.mov

  > 조회시 쉬프팅이 왜 생길까요 🤔 


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 