### PR TITLE
[Feature] DateTimePicker 초기값 스크롤 동기화

### DIFF
--- a/src/components/alarm/bottom-sheet/date-controller/ConfigPicker.tsx
+++ b/src/components/alarm/bottom-sheet/date-controller/ConfigPicker.tsx
@@ -17,7 +17,7 @@ const ConfigPicker = () => {
       <Row>
         <div>외출 날짜 및 시간</div>
         <Row>
-          <DateTimePicker initialDate={date} onChange={handleChange} />;
+          <DateTimePicker initialValue={date} onChange={handleChange} />
         </Row>
       </Row>
     );

--- a/src/components/scrollable-date-time-picker/ScrollBox.tsx
+++ b/src/components/scrollable-date-time-picker/ScrollBox.tsx
@@ -1,21 +1,24 @@
-import React, { FC, UIEventHandler, useEffect, useState } from 'react';
+import React, { FC, UIEventHandler, useCallback, useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 
 import ScrollItem from './ScrollItem';
 
 interface Props {
   items: string[] | number[];
+  value: string | number;
   onChange: (value: string | number) => void;
   align?: 'left' | 'center' | 'right';
   width?: number;
 }
 
-const ScrollBox: FC<Props> = ({ items, onChange, align = 'center', width = 80 }) => {
+const ScrollBox: FC<Props> = ({ value, items, onChange, align = 'center', width = 80 }) => {
+  const scrollBox = useRef<HTMLDivElement>(null);
   const [selectedItem, setSelectedItem] = useState(items[0]);
 
   useEffect(() => {
-    onChange(selectedItem);
-  }, [selectedItem]);
+    const pickedIdx = items.findIndex((item) => item === value);
+    scrollBox.current?.scrollTo(0, pickedIdx * BUTTON_HEIGHT);
+  }, [value]);
 
   const getIndexByOffsetY = (offsetY: number) => {
     const index = Math.round(offsetY / BUTTON_HEIGHT);
@@ -23,14 +26,14 @@ const ScrollBox: FC<Props> = ({ items, onChange, align = 'center', width = 80 })
     return index;
   };
 
-  const handleScroll: UIEventHandler = (e) => {
+  const handleScroll: UIEventHandler = useCallback((e) => {
     const index = getIndexByOffsetY((e.target as HTMLDivElement).scrollTop);
-
     setSelectedItem(items[index]);
-  };
+    onChange(items[index]);
+  }, []);
 
   return (
-    <Wrapper onScroll={handleScroll} width={width}>
+    <Wrapper onScroll={handleScroll} width={width} ref={scrollBox}>
       <InnerScrollBox>
         {['start-empty', ...items, 'end-empty'].map((item) => (
           <ScrollItem key={item} item={item} align={align} selectedItem={selectedItem} height={BUTTON_HEIGHT} />


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- date-time-picker의 초기값이 반영되지 않았어요.

## 🎉 어떻게 해결했나요?
- 초기값을 scrollTo 시켜줬어요.
- debounce를 적용시켰어요.

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
- 

https://user-images.githubusercontent.com/32628358/210084304-6c68a0dc-c6b0-4620-a430-c38a878bd61f.mov


 