### PR TITLE
에러바운더리 개발 및 적용

### DIFF
--- a/src/components/error-boundary/ErrorBoundary.tsx
+++ b/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, PropsWithChildren, ReactNode } from 'react';
+import { captureException } from '@sentry/nextjs';
+
+interface ErrorBoundaryProps {
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  errorMsg: string | null;
+}
+
+class ErrorBoundary extends Component<PropsWithChildren<ErrorBoundaryProps>, ErrorBoundaryState> {
+  constructor(props: PropsWithChildren<ErrorBoundaryProps>) {
+    super(props);
+    this.state = {
+      hasError: false,
+      errorMsg: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, errorMsg: error.name };
+  }
+
+  componentDidCatch(error: Error) {
+    captureException(error);
+  }
+
+  render() {
+    const { hasError, errorMsg } = this.state;
+    const { fallback, children } = this.props;
+
+    if (hasError) {
+      if (fallback) return fallback;
+      return <h1>error : {errorMsg}</h1>;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -13,6 +13,7 @@ import { RecoilRoot } from 'recoil';
 
 import 'dayjs/locale/ko';
 
+import ErrorBoundary from '@/components/error-boundary/ErrorBoundary';
 import ToastWrapper from '@/components/portal/ToastWrapper';
 import FcmTokenHandler from '@/components/push-notification/FcmTokenHandler';
 import RouteGuard from '@/components/route-guard/RouteGuard';
@@ -51,14 +52,16 @@ const MyApp = ({ Component: AppComponent, pageProps }: AppPropsWithLayout) => {
         <RecoilRoot>
           <ThemeProvider theme={lightTheme}>
             <LazyMotion features={domMax}>
-              <FcmTokenHandler>
-                <DefaultLayout>
-                  <Head />
-                  <GlobalStyles />
-                  <RouteGuard>{getLayout(<AppComponent {...pageProps} />)}</RouteGuard>
-                  <ToastWrapper />
-                </DefaultLayout>
-              </FcmTokenHandler>
+              <ErrorBoundary>
+                <FcmTokenHandler>
+                  <DefaultLayout>
+                    <Head />
+                    <GlobalStyles />
+                    <RouteGuard>{getLayout(<AppComponent {...pageProps} />)}</RouteGuard>
+                    <ToastWrapper />
+                  </DefaultLayout>
+                </FcmTokenHandler>
+              </ErrorBoundary>
             </LazyMotion>
           </ThemeProvider>
         </RecoilRoot>


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #236 

## 🎉 어떻게 해결했나요?
- 예측하지 못한 에러를 센트리에 기록하며 fallback을 보여주도록 error boundary를 개발했고, _app에 적용했어요

> 사실 mutation, query 등에서 던져지는 에러를 핸들링하기 위해 시작했으나 거기서 던져지는 것은 잡아내지 못하더라구요 !
-> 이건 `onError`에서 핸들링해야 할듯 싶어요!

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 