### PR TITLE
카드 아이템 추가 에러 핸들링

### DIFF
--- a/src/hooks/api/template/useCardItemMutation.ts
+++ b/src/hooks/api/template/useCardItemMutation.ts
@@ -6,6 +6,7 @@ import { Response as UserTemplateResponse, USER_TEMPLATE_QUERY_KEY } from './use
 import { del, patch, post } from '@/lib/api';
 import currentCategoryState from '@/store/route-home/currentCategory';
 import currentUserTemplateState from '@/store/route-home/currentUserTemplate';
+import useToast from '@/store/toast/useToast';
 
 interface createCardItemProps {
   itemName: string;
@@ -45,6 +46,8 @@ interface deleteCardItemRequest extends deleteCardItemProps {
 }
 
 const useCardItemMutation = () => {
+  const { fireToast } = useToast();
+
   const queryClient = useQueryClient();
 
   const currentCategory = useRecoilValue(currentCategoryState);
@@ -54,10 +57,10 @@ const useCardItemMutation = () => {
     queryClient.invalidateQueries([USER_TEMPLATE_QUERY_KEY, currentCategory?.id]);
   };
 
-  const createCardItemMutation = useMutation(
-    ({ itemName, important }: createCardItemProps) => {
-      if (!currentCategory) throw new Error('');
-      if (!currentTemplate) throw new Error('');
+  const createCardItemMutation = useMutation<undefined, Error, createCardItemProps>(
+    ({ itemName, important }) => {
+      if (!currentCategory) throw new Error('카테고리를 생성해 주세요.');
+      if (!currentTemplate) throw new Error('템플릿을 생성해 주세요.');
 
       const requestData: createCardItemRequest = {
         itemName,
@@ -71,6 +74,9 @@ const useCardItemMutation = () => {
     {
       onSuccess: () => {
         invalidateCurrentUserTemplate();
+      },
+      onError: (error) => {
+        fireToast({ content: error.message });
       },
     },
   );


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #235 

## 🎉 어떻게 해결했나요?
- `createCardItemMutation` 시 onError에서 toast 메세지를 띄우도록 했어요

이것도 반복되는 부분이 많을 거 같은데, 쿼리 클라이언트에서 일괄적으로 처리하는 게 좋을지 ..

> 하게 된다면 걱정되는 부분이라면 `useToast`가 recoil을 쓰고 있어서 컴포넌트를 한 번 분리? 해야된다는 점 이랄까요 (걱정이라기 보단 귀찮음에 가깝나 😱 )

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 

https://user-images.githubusercontent.com/26461307/210162548-f7fcd46b-92ee-4846-80f9-0fae8d8c86d5.mov

