### PR TITLE
[탐색] 바텀시트 내에서 추천 카테고리 선택 시 흰 화면이 지속되는 문제

### DIFF
--- a/src/components/route-search/TemplateAppendBottomSheet.tsx
+++ b/src/components/route-search/TemplateAppendBottomSheet.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps, useEffect } from 'react';
 import styled from '@emotion/styled';
-import { useQuery } from '@tanstack/react-query';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import LabelButton from '../button/LabelButton';
@@ -12,11 +11,9 @@ import BottomSheet from '../portal/BottomSheet';
 
 import CategorySection from './CategorySection';
 
-import { Category } from '@/hooks/api/category/type';
 import useGetUserCategories from '@/hooks/api/category/useGetUserCategories';
-import { UserTemplate } from '@/hooks/api/template/type';
 import useAppendToMyTemplate from '@/hooks/api/template/useAppendToMyTemplate';
-import { get } from '@/lib/api';
+import useGetUserTemplatesInSearchTab from '@/hooks/api/template/useGetUserTemplatesInSearchTab';
 import selectedCategoryState from '@/store/route-search/bottomSheet/selectedCategory';
 import selectedTemplateState from '@/store/route-search/bottomSheet/selectedTemplate';
 import { currentRecCategoryWithFlag } from '@/store/route-search/currentRecCategory';
@@ -119,32 +116,8 @@ const useUserCategories = () => {
   return { userCategories, isUserCategoriesLoading };
 };
 
-const useGetUserTemplates = () => {
-  interface Response {
-    result: UserTemplate[];
-  }
-
-  const selectedCategory = useRecoilValue(selectedCategoryState);
-
-  const getUserTemplate = (selectedCategory: Category | null) => {
-    if ('isRecCategory' in selectedCategory!) {
-      return Promise.resolve(null);
-    }
-    return get<Response>(`/template/user?category=${selectedCategory?.id}`);
-  };
-  const USER_TEMPLATE_QUERY_KEY = 'search_tab_user_template';
-
-  const query = useQuery({
-    queryKey: [USER_TEMPLATE_QUERY_KEY, selectedCategory],
-    queryFn: () => getUserTemplate(selectedCategory),
-    enabled: Boolean(selectedCategory),
-  });
-
-  return { ...query, data: query.data?.result };
-};
-
 const useUserTemplates = () => {
-  const { data: userTemplates, isLoading: isUserTemplatesLoading } = useGetUserTemplates();
+  const { data: userTemplates, isLoading: isUserTemplatesLoading } = useGetUserTemplatesInSearchTab();
   return { userTemplates, isUserTemplatesLoading };
 };
 

--- a/src/components/route-search/TemplateAppendBottomSheet.tsx
+++ b/src/components/route-search/TemplateAppendBottomSheet.tsx
@@ -29,7 +29,7 @@ const TemplateAppendBottomSheet = ({ isShowing, setToClose }: Props) => {
   const [selectedTemplate, setSelectedTemplate] = useRecoilState(selectedTemplateState);
 
   const { userCategories, isUserCategoriesLoading } = useUserCategories();
-  const { userTemplates, isUserTemplatesLoading } = useUserTemplates(selectedCategory);
+  const { userTemplates, isUserTemplatesLoading } = useUserTemplates();
 
   const currentRecCategory = useRecoilValue(currentRecCategoryWithFlag);
   const selectedRecTemplate = useRecoilValue(selectedRecTemplateState);
@@ -119,14 +119,16 @@ const useUserCategories = () => {
   return { userCategories, isUserCategoriesLoading };
 };
 
-const useGetUserTemplates = (selectedCategory: Category | null) => {
+const useGetUserTemplates = () => {
   interface Response {
     result: UserTemplate[];
   }
 
-  const getUserTemplate = () => {
-    if (selectedCategory?.isRecCategory) {
-      return;
+  const selectedCategory = useRecoilValue(selectedCategoryState);
+
+  const getUserTemplate = (selectedCategory: Category | null) => {
+    if ('isRecCategory' in selectedCategory!) {
+      return Promise.resolve(null);
     }
     return get<Response>(`/template/user?category=${selectedCategory?.id}`);
   };
@@ -134,15 +136,15 @@ const useGetUserTemplates = (selectedCategory: Category | null) => {
 
   const query = useQuery({
     queryKey: [USER_TEMPLATE_QUERY_KEY, selectedCategory],
-    queryFn: () => getUserTemplate(),
-    enabled: Boolean(selectedCategory?.id),
+    queryFn: () => getUserTemplate(selectedCategory),
+    enabled: Boolean(selectedCategory),
   });
 
   return { ...query, data: query.data?.result };
 };
 
-const useUserTemplates = (selectedUserCategory: Category | null) => {
-  const { data: userTemplates, isLoading: isUserTemplatesLoading } = useGetUserTemplates(selectedUserCategory);
+const useUserTemplates = () => {
+  const { data: userTemplates, isLoading: isUserTemplatesLoading } = useGetUserTemplates();
   return { userTemplates, isUserTemplatesLoading };
 };
 

--- a/src/hooks/api/template/useGetUserTemplatesInSearchTab.ts
+++ b/src/hooks/api/template/useGetUserTemplatesInSearchTab.ts
@@ -10,13 +10,24 @@ import selectedCategoryState from '@/store/route-search/bottomSheet/selectedCate
 
 interface Response {
   result: UserTemplate[];
+  error?: {
+    code: string;
+    message: string;
+    detail: string | null;
+  };
 }
 
-const getUserTemplate = (selectedCategory: Category | null) => {
+const getUserTemplate = async (selectedCategory: Category | null) => {
   if ('isRecCategory' in selectedCategory!) {
     return Promise.resolve(null);
   }
-  return get<Response>(`/template/user?category=${selectedCategory?.id}`);
+
+  const res = await get<Response>(`/template/user?category=${selectedCategory?.id}`);
+  if (res.error !== null && res.error?.code !== 'TEMPLATE_NOT_FOUND') {
+    throw new Error('');
+  }
+
+  return res;
 };
 
 const USER_TEMPLATE_QUERY_KEY = 'search_tab_user_template';

--- a/src/hooks/api/template/useGetUserTemplatesInSearchTab.ts
+++ b/src/hooks/api/template/useGetUserTemplatesInSearchTab.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue } from 'recoil';
+
+import { Category } from '../category/type';
+
+import { UserTemplate } from './type';
+
+import { get } from '@/lib/api';
+import selectedCategoryState from '@/store/route-search/bottomSheet/selectedCategory';
+
+interface Response {
+  result: UserTemplate[];
+}
+
+const getUserTemplate = (selectedCategory: Category | null) => {
+  if ('isRecCategory' in selectedCategory!) {
+    return Promise.resolve(null);
+  }
+  return get<Response>(`/template/user?category=${selectedCategory?.id}`);
+};
+
+const USER_TEMPLATE_QUERY_KEY = 'search_tab_user_template';
+
+const useGetUserTemplatesInSearchTab = () => {
+  const selectedCategory = useRecoilValue(selectedCategoryState);
+
+  const query = useQuery({
+    queryKey: [USER_TEMPLATE_QUERY_KEY, selectedCategory],
+    queryFn: () => getUserTemplate(selectedCategory),
+    enabled: Boolean(selectedCategory),
+  });
+
+  return { ...query, data: query.data?.result };
+};
+
+export default useGetUserTemplatesInSearchTab;


### PR DESCRIPTION
## 🤔 해결하려는 문제가 무엇인가요?
- resolve #241 
- 탐색 탭의 바텀시트 내에서 사용하는 `유저 템플릿 조회 쿼리 Hook`을 별도의 파일로 분리했어요
- 유저 템플릿 조회 응답값의 `TEMPLATE_NOT_FOUND` 에러 핸들링

## 🎉 어떻게 해결했나요?
- 카테고리에 템플릿이 0개일 경우 400번 에러를 던져주더라고요. 템플릿이 0개인 경우는 정상적인 응답에 해당한다고 생각해서, `res.error?.code !== 'TEMPLATE_NOT_FOUND'`인 경우에만 에러를 throw 했어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 