### PR TITLE
fix: framer children component에 key 추가

### DIFF
--- a/src/components/loading/LoadingHandler.tsx
+++ b/src/components/loading/LoadingHandler.tsx
@@ -22,7 +22,9 @@ const LoadingHandler: FC<PropsWithChildren<Props>> = ({ children, isLoading, fal
   const id = useId();
 
   return (
-    <AnimatePresence mode="wait">{isLoading ? <Fragment key={id}>{fallback}</Fragment> : children}</AnimatePresence>
+    <AnimatePresence mode="wait">
+      <Fragment key={id}>{isLoading ? fallback : children}</Fragment>
+    </AnimatePresence>
   );
 };
 

--- a/src/components/portal/ToastWrapper.tsx
+++ b/src/components/portal/ToastWrapper.tsx
@@ -12,7 +12,7 @@ const ToastWrapper = () => {
       <AnimatePresence mode="wait">
         {toast && (
           <MotionToastMessage
-            key={toast.content}
+            key={toast.content ?? 'toast'}
             variants={defaultFadeInUpVariants}
             initial="initial"
             animate="animate"

--- a/src/components/route-home/RecommendSection.tsx
+++ b/src/components/route-home/RecommendSection.tsx
@@ -21,6 +21,7 @@ const RecommendSection = () => {
   return (
     <AnimatePresence mode="wait">
       <Wrapper
+        key="recommend-section"
         animate={animationControls}
         drag="y"
         dragElastic={0}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- framer-motion children key가 없을때 키중복 에러가 발생

## 🎉 어떻게 해결했나요?
- key를 추가해줬어요.

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 