### PR TITLE
refactor: exception으로 error 핸들링

### DIFF
--- a/src/constants/message.ts
+++ b/src/constants/message.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line import/prefer-default-export
+export const errorMessage = {
+  UNKNOWN_400: '알 수 없는 에러가 발생했어요. 다시 시도해주세요.',
+  SERVER_500: '서버에 접속할 수 없어요. 다시 시도해주세요.',
+  TIMEOUT: '응답 시간을 초과했어요. 다시 시도해주세요.',
+};

--- a/src/exceptions/ApiException.ts
+++ b/src/exceptions/ApiException.ts
@@ -1,0 +1,16 @@
+import { ApiErrorScheme } from '@/models/api';
+
+class ApiException<ErrorCode = string> extends Error {
+  declare code: ErrorCode;
+
+  declare detail?: string;
+
+  constructor(data: ApiErrorScheme<ErrorCode>) {
+    super(data.message);
+    this.name = 'ApiException';
+    this.code = data.code;
+    this.detail = data.detail;
+  }
+}
+
+export default ApiException;

--- a/src/exceptions/CustomException.ts
+++ b/src/exceptions/CustomException.ts
@@ -1,0 +1,13 @@
+type CustomErrorCode = 'UNKNOWN_ERROR' | 'NETWORK_TIMEOUT' | 'NETWORK_ERROR';
+
+class CustomException extends Error {
+  declare code: CustomErrorCode;
+
+  constructor(message: string, code: CustomErrorCode) {
+    super(message);
+    this.name = 'CustomException';
+    this.code = code;
+  }
+}
+
+export default CustomException;

--- a/src/hooks/api/template/useGetUserTemplatesInSearchTab.ts
+++ b/src/hooks/api/template/useGetUserTemplatesInSearchTab.ts
@@ -6,15 +6,12 @@ import { Category } from '../category/type';
 import { UserTemplate } from './type';
 
 import { get } from '@/lib/api';
+import { ApiErrorScheme } from '@/models/api';
 import selectedCategoryState from '@/store/route-search/bottomSheet/selectedCategory';
 
 interface Response {
   result: UserTemplate[];
-  error?: {
-    code: string;
-    message: string;
-    detail: string | null;
-  };
+  error?: ApiErrorScheme;
 }
 
 const getUserTemplate = async (selectedCategory: Category | null) => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,9 @@
 import axios, { AxiosError, AxiosResponse } from 'axios';
 
+import { errorMessage } from '@/constants/message';
+import ApiException from '@/exceptions/ApiException';
+import CustomException from '@/exceptions/CustomException';
+import { ApiErrorScheme } from '@/models/api';
 import { isProd } from '@/utils/utils';
 
 const instance = axios.create({
@@ -18,8 +22,12 @@ const interceptorResponseFulfilled = (response: AxiosResponse) => {
   return Promise.reject(response.data);
 };
 
-const interceptorResponseRejected = (error: AxiosError<{ error: string }>) => {
-  return Promise.reject(new Error(error.response?.data?.error ?? error.name));
+const interceptorResponseRejected = (error: AxiosError<{ error: ApiErrorScheme }>) => {
+  if (error.response?.data?.error?.message && error.response?.data?.error?.code) {
+    return Promise.reject(new ApiException(error.response.data.error));
+  }
+
+  return Promise.reject(new CustomException(errorMessage.UNKNOWN_400, 'NETWORK_ERROR'));
 };
 
 instance.interceptors.response.use(interceptorResponseFulfilled, interceptorResponseRejected);

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -1,0 +1,5 @@
+export interface ApiErrorScheme<C = string> {
+  code: C;
+  message: string;
+  detail?: string;
+}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 정의된 에러가 없음
    - 에러가 예측불가능하고 타입가드가 되지 않음
- error를 유저에게 그대로 보여주지 않고 customMessage로 노출

## 🎉 어떻게 해결했나요?
- api error handling을 하기위해 exception으로 error를 새로 만들어 던짐
- 모든 에러는 new Error로 던지는게 아닌 new Exception으로 던짐으로써 무슨 에러인지 파악할 수 있게 함.
- 에러 name과 errorCode로 어느 catch구문에서도 에러를 핸들링할 수 있게 함.

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 