### PR TITLE
바텀시트 내 간격 수정

### DIFF
--- a/src/components/route-home/ListAppendBottomSheet.tsx
+++ b/src/components/route-home/ListAppendBottomSheet.tsx
@@ -108,7 +108,7 @@ const ItemFieldset = styled.fieldset({
   width: '100%',
 });
 
-const Legend = styled.legend({ height: '52px', display: 'flex', alignItems: 'center' }, ({ theme }) => ({
+const Legend = styled.legend({ padding: '14px 0' }, ({ theme }) => ({
   ...theme.typographies.body1,
   color: theme.colors.gray6,
 }));

--- a/src/components/route-home/category/CategoryRadioFieldset.tsx
+++ b/src/components/route-home/category/CategoryRadioFieldset.tsx
@@ -41,7 +41,10 @@ const CategoryRadioFieldset: FC<Props> = ({ currentCategory, setCurrentCategory 
 
 export default CategoryRadioFieldset;
 
-const Legend = styled.legend(({ theme }) => ({ ...theme.typographies.caption1, color: theme.colors.gray6 }));
+const Legend = styled.legend({ marginBottom: '8px' }, ({ theme }) => ({
+  ...theme.typographies.caption1,
+  color: theme.colors.gray6,
+}));
 
 interface RadioItemProps extends InputHTMLAttributes<HTMLInputElement> {
   text: string;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #239 

## 🎉 어떻게 해결했나요?
- QA 되었던 `리스트 추가`의 간격에 대한 수정을 했어요
  - 기존에 생각했던 방법인 `legend`와 `fieldset`을 걷어내는 방법이 아닌 `padding`을 주는 방법으로 했어요.
  - 접근성에 이점이 있다고 생각했기 때문이에요
  
- 둘러 보면서 찾은 `카테고리 추가`, `설정` 시 분류 밑의 간격에 대한 수정도 했어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 