### PR TITLE
소지품 추가 이후 입력값 초기화

### DIFF
--- a/src/components/route-home/CardItemAppendBottomSheet.tsx
+++ b/src/components/route-home/CardItemAppendBottomSheet.tsx
@@ -16,6 +16,7 @@ type Props = Omit<ComponentProps<typeof BottomSheet>, 'children'>;
 const CardItemAppendBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
   const {
     value: itemName,
+    resetValue: resetItemName,
     onChange: onChangeItemName,
     debouncedValue: debouncedItemName,
   } = useInput({ initialValue: '', useDebounce: true });
@@ -32,6 +33,7 @@ const CardItemAppendBottomSheet: FC<Props> = ({ isShowing, setToClose }) => {
       {
         onSuccess: () => {
           setToClose();
+          resetItemName();
         },
       },
     );

--- a/src/hooks/common/useInput.ts
+++ b/src/hooks/common/useInput.ts
@@ -37,6 +37,7 @@ type PropsWhenNotString<T> = WithRequired<Props<T>, 'parser'>;
 interface Return<T> {
   value: T;
   setValue: Dispatch<SetStateAction<T>>;
+  resetValue: VoidFunction;
   debouncedValue: T;
   onChange: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>) => void;
 }
@@ -53,6 +54,11 @@ function useInput<T extends string | number | boolean>({
 }: Props<T>) {
   const [value, setValue] = useState<T>(initialValue);
   const [debouncedValue, setDebouncedValue] = useState<T>(initialValue);
+
+  const resetValue = useCallback(() => {
+    setValue(initialValue);
+    setDebouncedValue(initialValue);
+  }, []);
 
   const handleDebounceValue = useMemo(
     () =>
@@ -76,7 +82,7 @@ function useInput<T extends string | number | boolean>({
     handleChangedValue(e.target.value as T);
   }, []);
 
-  return { value, setValue, debouncedValue, onChange };
+  return { value, setValue, resetValue, debouncedValue, onChange };
 }
 
 export default useInput;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- https://www.notion.so/depromeet/ad7424e22cc74d999ac82a52726b16af
- 소지품 추가 이후 다시 `추가하기`를 누르면 이전에 입력한 값이 있어요

## 🎉 어떻게 해결했나요?
- `useInput`에서 initialValue로 바꾸는 `resetValue` 기능을 제공하도록 했어요
- 추가 로직 성공 이후에 reset 하도록 했어요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 