### PR TITLE
앱 버전 리스닝

### DIFF
--- a/src/components/portal/Drawer.tsx
+++ b/src/components/portal/Drawer.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, FC, useState } from 'react';
+import { ComponentProps, FC } from 'react';
 import Link from 'next/link';
 import styled from '@emotion/styled';
 
@@ -9,19 +9,12 @@ import Svg from '../svg/Svg';
 
 import SideMenu from './SideMenu';
 
-import useListeningAppMessage from '@/hooks/bridge/useListeningAppMessage';
+import useAppVersionBridge from '@/hooks/bridge/app-version/useAppVersionBridge';
 
 type Props = Omit<ComponentProps<typeof SideMenu>, 'children'>;
 
 const Drawer: FC<Props> = ({ isShowing, setToClose }) => {
-  const [appVersion, setAppVersion] = useState<string | null>(null);
-
-  useListeningAppMessage({
-    targetType: 'APP_VERSION',
-    handler: ({ data }) => {
-      setAppVersion(data);
-    },
-  });
+  const { appVersion } = useAppVersionBridge();
 
   return (
     <SideMenu isShowing={isShowing} setToClose={setToClose}>
@@ -43,7 +36,6 @@ const Drawer: FC<Props> = ({ isShowing, setToClose }) => {
             <span>만든 사람들</span>
           </StyledNextLink>
         </LinkWrapper>
-
         {appVersion && (
           <VersionWrapper>
             <span>버전 정보</span>

--- a/src/components/portal/Drawer.tsx
+++ b/src/components/portal/Drawer.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, FC } from 'react';
+import { ComponentProps, FC, useState } from 'react';
 import Link from 'next/link';
 import styled from '@emotion/styled';
 
@@ -9,9 +9,20 @@ import Svg from '../svg/Svg';
 
 import SideMenu from './SideMenu';
 
+import useListeningAppMessage from '@/hooks/bridge/useListeningAppMessage';
+
 type Props = Omit<ComponentProps<typeof SideMenu>, 'children'>;
 
 const Drawer: FC<Props> = ({ isShowing, setToClose }) => {
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  useListeningAppMessage({
+    targetType: 'APP_VERSION',
+    handler: ({ data }) => {
+      setAppVersion(data);
+    },
+  });
+
   return (
     <SideMenu isShowing={isShowing} setToClose={setToClose}>
       <Wrapper>
@@ -32,11 +43,14 @@ const Drawer: FC<Props> = ({ isShowing, setToClose }) => {
             <span>만든 사람들</span>
           </StyledNextLink>
         </LinkWrapper>
-        <VersionWrapper>
-          <span>버전 정보</span>
-          {/* TODO: App에서 버전 정보 받아와서 보여주기 */}
-          <span>1.0</span>
-        </VersionWrapper>
+
+        {appVersion && (
+          <VersionWrapper>
+            <span>버전 정보</span>
+
+            <span>{appVersion}</span>
+          </VersionWrapper>
+        )}
       </Wrapper>
     </SideMenu>
   );

--- a/src/hooks/bridge/app-version/useAppVersionBridge.ts
+++ b/src/hooks/bridge/app-version/useAppVersionBridge.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+import postAppMessage from '../postAppMessage';
+import useListeningAppMessage from '../useListeningAppMessage';
+
+import useDidMount from '@/hooks/life-cycle/useDidMount';
+
+const useAppVersionBridge = () => {
+  const [appVersion, setAppVersion] = useState<string | null>(null);
+
+  useListeningAppMessage({
+    targetType: 'APP_VERSION',
+    handler: ({ data }) => {
+      console.error(data);
+      setAppVersion(data);
+    },
+  });
+
+  useDidMount(() => {
+    postAppMessage<undefined>({ type: 'APP_VERSION', data: undefined });
+  });
+
+  return { appVersion };
+};
+
+export default useAppVersionBridge;

--- a/src/hooks/bridge/postAppMessage.ts
+++ b/src/hooks/bridge/postAppMessage.ts
@@ -3,7 +3,7 @@ import { PostAppMessageData } from './type';
 /**
  * `Web`에서 `App`으로 데이터를 전송합니다.
  */
-const postAppMessage = ({ type, data, ...rest }: PostAppMessageData) => {
+const postAppMessage = <T>({ type, data, ...rest }: PostAppMessageData<T>) => {
   if (!window?.ReactNativeWebView) return;
 
   window.ReactNativeWebView.postMessage(JSON.stringify({ type, data, ...rest }));

--- a/src/hooks/bridge/type.ts
+++ b/src/hooks/bridge/type.ts
@@ -1,15 +1,15 @@
-export type LISTENLING_WEBVIEW_MESSAGE_KEY = 'FCM_TOKEN';
+export type LISTENLING_WEBVIEW_MESSAGE_KEY = 'FCM_TOKEN' | 'APP_VERSION';
 
 export type POST_WEBVIEW_MESSAGE_KEY = 'baz';
 
-export interface ListeningAppMessageData {
+export interface ListeningAppMessageData<T = string> {
   type: LISTENLING_WEBVIEW_MESSAGE_KEY;
-  data: unknown;
+  data: T;
   [key: string]: unknown;
 }
 
-export interface PostAppMessageData {
+export interface PostAppMessageData<T = unknown> {
   type: POST_WEBVIEW_MESSAGE_KEY;
-  data: unknown;
+  data: T;
   [key: string]: unknown;
 }

--- a/src/hooks/bridge/type.ts
+++ b/src/hooks/bridge/type.ts
@@ -1,6 +1,6 @@
 export type LISTENLING_WEBVIEW_MESSAGE_KEY = 'FCM_TOKEN' | 'APP_VERSION';
 
-export type POST_WEBVIEW_MESSAGE_KEY = 'baz';
+export type POST_WEBVIEW_MESSAGE_KEY = 'APP_VERSION';
 
 export interface ListeningAppMessageData<T = string> {
   type: LISTENLING_WEBVIEW_MESSAGE_KEY;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #228 
- 앱 버전 정보를 그려요
  - 만약 앱 환경이 아니라면 그리지 않아요

## 🎉 어떻게 해결했나요?
- 기존에 개발해 두었던 `useListeningAppMessage`와 `postAppMessage`를 이용했어요

- app에서 `onLoad`시에 메세지를 보내면 `dynamic` 임포트되는 `drawer`에서 listening이 되지 않더라구요
  - 그래서 `postAppMessage`를 보낸 후, app에서 메세지를 보내고 그것을 확인하도록 했어요

- `postAppMessage`, `ListeningAppMessageData`에 타입을 제너릭해 사용할 수 있도록 했어요


프리뷰 주소를 통해 앱 환경에서 테스트 해 볼게요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 