### PR TITLE
간혈적 무한 로딩 현상 해결

### DIFF
--- a/src/components/route-home/category/CategorySection.tsx
+++ b/src/components/route-home/category/CategorySection.tsx
@@ -95,7 +95,7 @@ const useCategories = () => {
 
   useEffect(() => {
     if (!query.data) return;
-    if (currentCategory !== null) return;
+    if (currentCategory) return;
 
     setCurrentCategory(query.data[0]);
   }, [query.data]);


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #260 

## 🎉 어떻게 해결했나요?

온보딩에서 홈으로 넘어갈 때 `카테고리 조회`, `사용자 템플릿 조회 (카테고리가 선택된 상태에서)` 이 두 개의 조회가 이루어져요

문제는 카테고리 조회 이후에 초기 첫 번째 카테고리를 전역 상태로 set하는 과정에 있었는데요

현재 선택된 카테고리가 있을 경우 넘어가는 로직을 `!== null`로 비교를 해서 발생했었어요.

조회되기 전 (로딩중 일 때) null이 아닌 undefined가 set된 이후에, 조회된 후 set을 할려는데 `undefined !== null`이라 발생했었어요!



  


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 