### PR TITLE
fix: fcm token api spec 변경

### DIFF
--- a/src/hooks/api/pushAlarm/useSendFcmToken.ts
+++ b/src/hooks/api/pushAlarm/useSendFcmToken.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { useRecoilValue } from 'recoil';
 
-import { get } from '@/lib/api';
+import { post, replaceUserTokenToInstance } from '@/lib/api';
 import userTokenState from '@/store/localStorage/userToken';
 import fcmTokenState from '@/store/push-notification/fcmToken';
 
@@ -10,15 +10,19 @@ const useSendFcmToken = () => {
   const fcmToken = useRecoilValue(fcmTokenState);
   const userToken = useRecoilValue(userTokenState);
 
-  const sendFcmTokenMutation = useMutation(() => {
-    return get(`/alarm?token=${fcmToken}`);
+  const sendFcmTokenMutation = useMutation((token: string) => {
+    return post(`/user/token`, { fcmToken: token });
   });
 
   const { mutate } = sendFcmTokenMutation;
 
   useEffect(() => {
+    if (userToken) {
+      replaceUserTokenToInstance(userToken);
+    }
+
     if (fcmToken && userToken) {
-      mutate();
+      mutate(fcmToken);
     }
   }, [mutate, fcmToken, userToken]);
 };


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- fcm 갱신 api가 호출되지 않고 있었어요.

## 🎉 어떻게 해결했나요?
- api-docs spec으로 api-spec을 갱신했어요.

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
- http://ahmatda.com/docs/index.html#_fcm_token_%EA%B0%B1%EC%8B%A0
 