### PR TITLE
사용자 카테고리 설정 마크업 수정

### DIFF
--- a/src/components/route-home/category/CategoryAppendBottomSheet.tsx
+++ b/src/components/route-home/category/CategoryAppendBottomSheet.tsx
@@ -6,8 +6,8 @@ import AppBar from '../../navigation/AppBar';
 import BottomSheet from '../../portal/BottomSheet';
 import TextField from '../../text-field/TextField';
 
-import CategoryIconRadioFieldset from './CategoryIconRadioFieldset';
-import CategoryRadioFieldset from './CategoryRadioFieldset';
+import CategoryIconRadioFieldset from './CategoryIconRadioGroup';
+import CategoryRadioFieldset from './CategoryRadioGroup';
 
 import { Graphic } from '@/components/graphic/type';
 import { CategoryKind } from '@/hooks/api/category/type';

--- a/src/components/route-home/category/CategoryEditBottomSheet.tsx
+++ b/src/components/route-home/category/CategoryEditBottomSheet.tsx
@@ -1,8 +1,8 @@
 import { ComponentProps, FC, useState } from 'react';
 import styled from '@emotion/styled';
 
-import CategoryIconRadioFieldset from './CategoryIconRadioFieldset';
-import CategoryRadioFieldset from './CategoryRadioFieldset';
+import CategoryIconRadioFieldset from './CategoryIconRadioGroup';
+import CategoryRadioFieldset from './CategoryRadioGroup';
 
 import LabelButton from '@/components/button/LabelButton';
 import { Graphic } from '@/components/graphic/type';

--- a/src/components/route-home/category/CategoryIconRadioGroup.tsx
+++ b/src/components/route-home/category/CategoryIconRadioGroup.tsx
@@ -33,8 +33,8 @@ const CategoryIconRadioGroup: FC<Props> = ({ currentValue, setCurrentValue }) =>
   };
 
   return (
-    <fieldset>
-      <Legend>아이콘 *</Legend>
+    <div>
+      <Span>아이콘 *</Span>
       <Wrapper>
         {categoryGraphics.map((type) => (
           <Fragment key={type}>
@@ -45,13 +45,16 @@ const CategoryIconRadioGroup: FC<Props> = ({ currentValue, setCurrentValue }) =>
           </Fragment>
         ))}
       </Wrapper>
-    </fieldset>
+    </div>
   );
 };
 
 export default CategoryIconRadioGroup;
 
-const Legend = styled.legend(({ theme }) => ({ ...theme.typographies.caption1, color: theme.colors.gray6 }));
+const Span = styled.span(({ theme }) => ({
+  ...theme.typographies.caption1,
+  color: theme.colors.gray6,
+}));
 
 const Wrapper = styled.div({
   display: 'flex',

--- a/src/components/route-home/category/CategoryRadioGroup.tsx
+++ b/src/components/route-home/category/CategoryRadioGroup.tsx
@@ -11,7 +11,7 @@ interface Props {
   setCurrentCategory: Dispatch<SetStateAction<CategoryKind>>;
 }
 
-const CategoryRadioFieldset: FC<Props> = ({ currentCategory, setCurrentCategory }) => {
+const CategoryRadioGroup: FC<Props> = ({ currentCategory, setCurrentCategory }) => {
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget;
 
@@ -21,8 +21,8 @@ const CategoryRadioFieldset: FC<Props> = ({ currentCategory, setCurrentCategory 
   };
 
   return (
-    <fieldset>
-      <Legend>카테고리 *</Legend>
+    <div>
+      <Span>카테고리 *</Span>
       <div style={{ width: '100%', display: 'flex', gap: '8px' }}>
         {objectKeys(CATEGORY_KIND).map((category) => (
           <RadioItem
@@ -35,13 +35,13 @@ const CategoryRadioFieldset: FC<Props> = ({ currentCategory, setCurrentCategory 
           />
         ))}
       </div>
-    </fieldset>
+    </div>
   );
 };
 
-export default CategoryRadioFieldset;
+export default CategoryRadioGroup;
 
-const Legend = styled.legend({ marginBottom: '8px' }, ({ theme }) => ({
+const Span = styled.span({ marginBottom: '8px' }, ({ theme }) => ({
   ...theme.typographies.caption1,
   color: theme.colors.gray6,
 }));


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #279 

- 이전에도 문제가 되었던 fieldset과 legend 관련된 문제로 확인이 됐어요

## 🎉 어떻게 해결했나요?
- fieldset, legend 태그들을 걷어냈어요
  - 이전에 공유드린 아티클에서 본 것처럼 예측하기 어려운 마크업이 되는 것 같다고 생각했어요

- 다른 곳에 적용된 부분은 점진적으로 걷어내면 좋을 거 같아요

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 