### PR TITLE
carousel indicator index 오류 수정

### DIFF
--- a/src/components/carousel/Indicator.tsx
+++ b/src/components/carousel/Indicator.tsx
@@ -69,7 +69,7 @@ const useIndicator = ({ carouselWrapper, onIndexChange }: Pick<Props, 'carouselW
       throttle(() => {
         if (!carouselWrapper) return;
         const { offsetWidth, scrollLeft } = carouselWrapper;
-        const tempIndex = Math.round(scrollLeft / offsetWidth);
+        const tempIndex = Math.floor(scrollLeft / offsetWidth);
         setCurrentIndex(tempIndex);
       }, 300),
     [carouselWrapper],


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #293 
- 5번째 카드가 Indicator index가 정확하게 계산이 되지 않았습니다

## 🎉 어떻게 해결했나요?
- `Math.round`를 수행하고 있어 발생한 이슈였어요. `floor`를 통해 버림으로 수정했습니다.

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 