### PR TITLE
홈에서 뒤로가기 접근 제어를 위한 온보딩 로직 변경

### DIFF
--- a/src/pages/onboard/step1.page.tsx
+++ b/src/pages/onboard/step1.page.tsx
@@ -34,7 +34,7 @@ const Step1 = () => {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    router.push('/onboard/step2');
+    router.replace('/onboard/step2');
     recordEvent({ action: '온보딩 1', value: selectedCategory });
   };
 

--- a/src/pages/onboard/step2.page.tsx
+++ b/src/pages/onboard/step2.page.tsx
@@ -34,15 +34,14 @@ const Step2 = () => {
     recordEvent({ action: '온보딩 2', value: item.name });
   };
 
-  const onSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    router.push('/onboard/step3');
+  const onClickNext = () => {
+    router.replace('/onboard/step3');
   };
 
   return (
     <>
       <WhiteBackgroundGlobalStyles />
-      <AppBar onClickBackButton={() => router.push('/onboard/step1')} />
+      <AppBar onClickBackButton={() => router.replace('/onboard/step1')} />
       <Wrapper>
         <TitleSection
           title={ONBOARD_TITLE[selectedCategory.type].title}
@@ -54,27 +53,26 @@ const Step2 = () => {
             </>
           }
         />
-        <form onSubmit={onSubmit}>
-          <SelectSection variants={staggerHalf} initial="initial" animate="animate" exit="exit">
-            {ONBOARD_ITEMS[selectedCategory.type].map((item) => (
-              <Item
-                key={item.name}
-                name="items"
-                value={item.name}
-                label={item.name}
-                emjCode={<Graphic type={item.emoji} isAct={selectedItems.indexOf(item) !== -1} />}
-                labelSize="small"
-                onChange={(e) => onChange(e, item)}
-                checked={selectedItems.indexOf(item) !== -1}
-              />
-            ))}
-          </SelectSection>
-          <ButtonSection>
-            <ContainedButton type="submit" size="large" disabled={isCheckAny}>
-              다음
-            </ContainedButton>
-          </ButtonSection>
-        </form>
+
+        <SelectSection variants={staggerHalf} initial="initial" animate="animate" exit="exit">
+          {ONBOARD_ITEMS[selectedCategory.type].map((item) => (
+            <Item
+              key={item.name}
+              name="items"
+              value={item.name}
+              label={item.name}
+              emjCode={<Graphic type={item.emoji} isAct={selectedItems.indexOf(item) !== -1} />}
+              labelSize="small"
+              onChange={(e) => onChange(e, item)}
+              checked={selectedItems.indexOf(item) !== -1}
+            />
+          ))}
+        </SelectSection>
+        <ButtonSection>
+          <ContainedButton type="button" size="large" disabled={isCheckAny} onClick={onClickNext}>
+            다음
+          </ContainedButton>
+        </ButtonSection>
       </Wrapper>
     </>
   );

--- a/src/pages/onboard/step3.page.tsx
+++ b/src/pages/onboard/step3.page.tsx
@@ -61,14 +61,14 @@ const Step3 = () => {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    router.push('/onboard/step4');
+    router.replace('/onboard/step4');
     recordEvent({ action: '온보딩 3', value: isCheckAny ? '템플릿 선택' : '템플릿 선택 안함' });
   };
 
   return (
     <>
       <WhiteBackgroundGlobalStyles />
-      <AppBar onClickBackButton={() => router.push('/onboard/step2')} />
+      <AppBar onClickBackButton={() => router.replace('/onboard/step2')} />
       <Wrapper>
         <TitleSection
           title={


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #298 
- 온보딩 이후 홈에서 안드로이드 기기에서 뒤로 가기 시 온보딩으로 이동함
  - 온보딩 스탭 4에서는 router replace를 하고 있으나, 이전 스탭들에서는 하고 있지 않음

## 🎉 어떻게 해결했나요?

- history stack을 비울 수 있는 방법이 있는 지 확인해 봤는데 현재로써는 없더라구요
  - [`deleteAll`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteAll) 이란 게 있긴 하나 저희가 사용하는 디바이스에서는 지원을 안하더라구요

- 그래서 ~ `RouteGuard`에서 '토큰이 있으며, 온보딩에 방문'한 경우를 핸들링하는 방향으로 1차원적으로 개발했으나

  - 온보딩은 처음 접한 사용자만 보는 화면이고, 이외의 사용자들에게까지 그런 로직을 수행하는게 합리적이라고는 생각이 들지 않았어요
  - 제일 큰 이유는 화면이 매끄럽게 보이지 않았어요 (제 잘못)
  
- 그래서 ~ 온보딩 route들에 있는 push들을 replace로 다 바꿨습니다 !
  - UI로 뒤로 갈 수 있어서 불편하지 않을 것이라 생각했어요.
  - 관련해서 `step2`에서 form을 쓰고 있었는데, 꼭 사용해야되는 이유가 없어 보여 걷어 냈어요 (이유가 있다면 알려주세요 !!)

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 