### PR TITLE
홈, 탐색 탭 로딩 사용성 개선

### DIFF
--- a/src/components/route-home/Card.tsx
+++ b/src/components/route-home/Card.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
+import { m } from 'framer-motion';
 
 import AlarmBottomSheet from '../alarm/bottom-sheet/AlarmBottomSheet';
 import LabelButton from '../button/LabelButton';
@@ -9,6 +10,7 @@ import IconSetting from '../icon/IconSetting';
 
 import CardItem from './CardItem';
 
+import { homeCardVariants } from '@/constants/motions';
 import { UserTemplate } from '@/hooks/api/template/type';
 import useToggle from '@/hooks/common/useToggle';
 
@@ -24,7 +26,7 @@ const Card = ({ id, templateName, alarmInfo, items, pin }: Props) => {
 
   return (
     <>
-      <Wrapper>
+      <Wrapper variants={homeCardVariants} initial="initial" animate="animate" exit="exit">
         <TitleHeading>{templateName}</TitleHeading>
         {alarmInfo && <AlarmCycleSpan>{alarmInfo}</AlarmCycleSpan>}
         {/* <PinButton type="button">
@@ -67,7 +69,7 @@ const Card = ({ id, templateName, alarmInfo, items, pin }: Props) => {
 
 export default Card;
 
-const Wrapper = styled.div(
+const Wrapper = styled(m.div)(
   {
     position: 'relative',
     width: '100%',

--- a/src/components/route-home/EmptyCard.tsx
+++ b/src/components/route-home/EmptyCard.tsx
@@ -1,10 +1,12 @@
 import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
+import { m } from 'framer-motion';
 
 import LabelButton from '../button/LabelButton';
 import GraphicEmptyCard from '../graphic/GraphicEmptyCard';
 import IconAdd from '../icon/IconAdd';
 
+import { homeCardVariants } from '@/constants/motions';
 import useToggle from '@/hooks/common/useToggle';
 
 const ListAppendBottomSheet = dynamic(() => import('./ListAppendBottomSheet'));
@@ -14,7 +16,7 @@ const EmptyCard = () => {
 
   return (
     <>
-      <Wrapper>
+      <Wrapper variants={homeCardVariants} initial="initial" animate="animate" exit="exit">
         <GraphicWrapper>
           <GraphicEmptyCard />
         </GraphicWrapper>
@@ -32,7 +34,7 @@ const EmptyCard = () => {
 
 export default EmptyCard;
 
-const Wrapper = styled.div({
+const Wrapper = styled(m.div)({
   width: '100%',
   minHeight: '410px',
   height: '100%',

--- a/src/constants/motions.ts
+++ b/src/constants/motions.ts
@@ -48,3 +48,23 @@ export const defaultFadeInUpVariants: Variants = {
     willChange: 'opacity, transform',
   },
 };
+
+export const homeCardVariants: Variants = {
+  initial: {
+    opacity: 0,
+    y: 10,
+    transition: { duration: 0.5, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: { duration: 0.5, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+  exit: {
+    opacity: 0,
+    transition: { duration: 0.5, ease: defaultEasing },
+    willChange: 'opacity, transform',
+  },
+};

--- a/src/pages/index.page.tsx
+++ b/src/pages/index.page.tsx
@@ -1,10 +1,10 @@
 import { ReactElement, useState } from 'react';
+import { AnimatePresence } from 'framer-motion';
+import { useRecoilValue } from 'recoil';
 
 import { NextPageWithLayout } from './_app.page';
 
 import Carousel from '@/components/carousel/Carousel';
-import FixedSpinner from '@/components/loading/FixedSpinner';
-import LoadingHandler from '@/components/loading/LoadingHandler';
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import Card from '@/components/route-home/Card';
@@ -13,21 +13,24 @@ import EmptyCard from '@/components/route-home/EmptyCard';
 import RecommendSection from '@/components/route-home/RecommendSection';
 import useGetUserTemplate from '@/hooks/api/template/useGetUserTemplate';
 import useCurrentUserTemplate from '@/hooks/route-home/useCurrentUserTemplate';
+import currentCategoryState from '@/store/route-home/currentCategory';
 
 const HomePage: NextPageWithLayout = () => {
   const [carouselWrapper, setCarouselWrapper] = useState<HTMLDivElement | null>(null);
-  const { data, isLoading } = useGetUserTemplate();
+  const { data } = useGetUserTemplate();
   const { onCarouselIndexChange } = useCurrentUserTemplate();
+  const currentCategory = useRecoilValue(currentCategoryState);
 
   return (
     <>
       <CategorySection />
 
-      <LoadingHandler fallback={<FixedSpinner />} isLoading={isLoading}>
-        <Carousel.Wrapper ref={setCarouselWrapper}>
+      <AnimatePresence mode="wait">
+        <Carousel.Wrapper key={currentCategory?.id} ref={setCarouselWrapper}>
           {data?.map((userTemplate) => (
             <Carousel.Item key={userTemplate.id}>
               <Card
+                key={userTemplate.id}
                 id={userTemplate.id}
                 templateName={userTemplate.templateName}
                 alarmInfo={userTemplate.alarmInfo}
@@ -43,9 +46,9 @@ const HomePage: NextPageWithLayout = () => {
             <EmptyCard />
           </Carousel.Item>
         </Carousel.Wrapper>
+      </AnimatePresence>
 
-        <Carousel.Indicator carouselWrapper={carouselWrapper} onIndexChange={onCarouselIndexChange} />
-      </LoadingHandler>
+      <Carousel.Indicator carouselWrapper={carouselWrapper} onIndexChange={onCarouselIndexChange} />
 
       <RecommendSection />
     </>

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -5,7 +5,6 @@ import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { NextPageWithLayout } from '../_app.page';
 
-import FixedSpinner from '@/components/loading/FixedSpinner';
 import LoadingHandler from '@/components/loading/LoadingHandler';
 import BottomNavigation from '@/components/navigation/BottomNavigation';
 import DefaultAppBar from '@/components/navigation/DefaultAppBar';
@@ -24,9 +23,18 @@ const TemplateAppendBottomSheet = dynamic(() => import('@/components/route-searc
 const Template: NextPageWithLayout = () => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
-  const { data: categories, currentRecCategory, setCurrentRecCategory } = useRecCategories();
+  const {
+    data: categories,
+    currentRecCategory,
+    setCurrentRecCategory,
+    isLoading: isRecCategoryLoading,
+  } = useRecCategories();
 
-  const { data: templates, isRefetching: isRefetchingRecTemplates, isLoading } = useGetRecTemplates();
+  const {
+    data: templates,
+    isRefetching: isRefetchingRecTemplates,
+    isLoading: isRecTemplatesLoading,
+  } = useGetRecTemplates();
   const setSelectedRecTemplate = useSetRecoilState(selectedRecTemplateState);
 
   const onRecTemplateSubmit = (templateInfo: RecTemplate) => () => {
@@ -41,13 +49,13 @@ const Template: NextPageWithLayout = () => {
 
   return (
     <>
-      <LoadingHandler isLoading={isLoading} fallback={<FixedSpinner />}>
-        <Wrapper>
-          <Title>
-            상황에 맞는
-            <br />
-            소지품을 추천해 드릴게요
-          </Title>
+      <Wrapper>
+        <Title>
+          상황에 맞는
+          <br />
+          소지품을 추천해 드릴게요
+        </Title>
+        <LoadingHandler isLoading={isRecCategoryLoading} fallback={null}>
           <CategorySection
             options={categories}
             selectedCategory={currentRecCategory}
@@ -55,6 +63,9 @@ const Template: NextPageWithLayout = () => {
               setCurrentRecCategory(clickedCategory);
             }}
           />
+        </LoadingHandler>
+
+        <LoadingHandler isLoading={isRecTemplatesLoading} fallback={null}>
           <CardsWrapper>
             {templates?.map((templateInfo) => (
               <RecommendationTemplateCard
@@ -66,9 +77,10 @@ const Template: NextPageWithLayout = () => {
               />
             ))}
           </CardsWrapper>
-          <ListRequestSection />
-        </Wrapper>
-      </LoadingHandler>
+        </LoadingHandler>
+
+        <ListRequestSection />
+      </Wrapper>
 
       <TemplateAppendBottomSheet
         isShowing={isBottomSheetOpen}


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #305 
- 홈 탭과 탐색 탭에서 `FixedSpinner`를 로딩 시 그려주고 있어서, 화면의 부분 로딩이 가능한 경우에도 전체 화면이 깜빡이듯이 보이고 있어요

## 🎉 어떻게 해결했나요?
- 탐색 탭에서 로딩 핸들러를 카테고리와 템플릿으로 나누어 그려주었어요 
  - 근데 fallback으로 `null`을 넣는 경우는 그냥 `condition && <Foo />` 처럼 그려주는 것이 나을 거 같기도 하네요 ㅠ

- 홈 탭에서 로딩 핸들러를 걷어내고 [AnimatePresence](https://www.framer.com/motion/animate-presence/)를 사용해서 애니메이션을 적용했어요
  - ~~애니메이션에 대해 디자이너분들 피드백을 기다리고 있어요~~
  - 탐색 탭에서도 비슷하게 적용하는 게 일관된 사용성을 제공하는 방향이 될 거 같아요


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 