### PR TITLE
탐색 탭 로딩 사용성 개선

### DIFF
--- a/src/components/route-search/RecommendationTemplateCard.tsx
+++ b/src/components/route-search/RecommendationTemplateCard.tsx
@@ -1,11 +1,13 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
+import { m } from 'framer-motion';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import ContainedButton from '../button/ContainedButton';
 import Checkbox from '../checkbox/Checkbox';
 import CheckboxWithText from '../checkbox/CheckboxWithText';
 
+import { homeCardVariants } from '@/constants/motions';
 import { RecTemplate } from '@/hooks/api/template/type';
 import selectedRecItemsState from '@/store/route-search/selectedRecItems';
 import selectedRecTemplateState from '@/store/route-search/selectedRecTemplate';
@@ -69,7 +71,7 @@ const RecommendationTemplateCard = ({ data, submitBtnTitle, onSubmit, isRefetchi
   }, [isRefetchingTemplateData]);
 
   return (
-    <Wrapper>
+    <Wrapper variants={homeCardVariants}>
       <StyledHeader>
         <Title>{templateName}</Title>
         <Checkbox textLabel="전체 선택" onToggle={toggleCheckAllBtn} checked={numCheckedItems === items.length} />
@@ -100,7 +102,7 @@ const RecommendationTemplateCard = ({ data, submitBtnTitle, onSubmit, isRefetchi
 
 export default RecommendationTemplateCard;
 
-const Wrapper = styled.div`
+const Wrapper = styled(m.div)`
   border-radius: 16px;
   background-color: ${({ theme }) => theme.colors.white};
   padding: 20px 20px 16px 20px;

--- a/src/pages/template/index.page.tsx
+++ b/src/pages/template/index.page.tsx
@@ -1,6 +1,7 @@
 import { ReactElement, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
 import styled from '@emotion/styled';
+import { AnimatePresence, m } from 'framer-motion';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { NextPageWithLayout } from '../_app.page';
@@ -11,6 +12,7 @@ import DefaultAppBar from '@/components/navigation/DefaultAppBar';
 import CategorySection from '@/components/route-search/CategorySection';
 import ListRequestSection from '@/components/route-search/ListRequestSection';
 import RecommendationTemplateCard from '@/components/route-search/RecommendationTemplateCard';
+import { staggerOne } from '@/constants/motions';
 import useGetRecCategories from '@/hooks/api/category/useGetRecCategories';
 import { RecTemplate } from '@/hooks/api/template/type';
 import useGetRecTemplates from '@/hooks/api/template/useGetRecTemplates';
@@ -30,11 +32,7 @@ const Template: NextPageWithLayout = () => {
     isLoading: isRecCategoryLoading,
   } = useRecCategories();
 
-  const {
-    data: templates,
-    isRefetching: isRefetchingRecTemplates,
-    isLoading: isRecTemplatesLoading,
-  } = useGetRecTemplates();
+  const { data: templates, isRefetching: isRefetchingRecTemplates } = useGetRecTemplates();
   const setSelectedRecTemplate = useSetRecoilState(selectedRecTemplateState);
 
   const onRecTemplateSubmit = (templateInfo: RecTemplate) => () => {
@@ -65,8 +63,14 @@ const Template: NextPageWithLayout = () => {
           />
         </LoadingHandler>
 
-        <LoadingHandler isLoading={isRecTemplatesLoading} fallback={null}>
-          <CardsWrapper>
+        <AnimatePresence mode="wait">
+          <CardsWrapper
+            key={currentRecCategory?.id}
+            variants={staggerOne}
+            initial="initial"
+            animate="animate"
+            exit="exit"
+          >
             {templates?.map((templateInfo) => (
               <RecommendationTemplateCard
                 key={`rec-template-${templateInfo.id}`}
@@ -77,7 +81,7 @@ const Template: NextPageWithLayout = () => {
               />
             ))}
           </CardsWrapper>
-        </LoadingHandler>
+        </AnimatePresence>
 
         <ListRequestSection />
       </Wrapper>
@@ -114,7 +118,7 @@ const Title = styled.p`
   margin-bottom: 24px;
 `;
 
-const CardsWrapper = styled.div`
+const CardsWrapper = styled(m.div)`
   display: flex;
   flex-direction: column;
   row-gap: 16px;


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->



<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- close #308 
- 탐색 탭의 추천 카테고리 변경시 뚝뚝 끊기는 것처럼 보이는 것이 불편했어요

## 🎉 어떻게 해결했나요?
- 기존 사용하던 로딩 핸들러를 걷어내고, `AnimatePresence`와 함께 애니메이션을 주었어요


### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->
 

https://user-images.githubusercontent.com/26461307/217145909-dbc6eb1a-af82-42d7-849c-583b05ef70de.mov

