### PR TITLE
중복된 아이템 생성 핸들링

### DIFF
--- a/src/hooks/api/template/useCardItemMutation.ts
+++ b/src/hooks/api/template/useCardItemMutation.ts
@@ -3,6 +3,7 @@ import { useRecoilValue } from 'recoil';
 
 import { Response as UserTemplateResponse, USER_TEMPLATE_QUERY_KEY } from './useGetUserTemplate';
 
+import recordEvent from '@/lib/analytics/record';
 import { del, patch, post } from '@/lib/api';
 import currentCategoryState from '@/store/route-home/currentCategory';
 import currentUserTemplateState from '@/store/route-home/currentUserTemplate';
@@ -63,6 +64,7 @@ const useCardItemMutation = () => {
       if (!currentTemplate) throw new Error('템플릿을 생성해 주세요.');
 
       if (currentTemplate.items.find((item) => item.name === itemName)) {
+        recordEvent({ action: '중복 소지품 추가', value: itemName });
         throw new Error('이미 존재하는 아이템입니다.');
       }
 

--- a/src/hooks/api/template/useCardItemMutation.ts
+++ b/src/hooks/api/template/useCardItemMutation.ts
@@ -63,8 +63,7 @@ const useCardItemMutation = () => {
       if (!currentTemplate) throw new Error('템플릿을 생성해 주세요.');
 
       if (currentTemplate.items.find((item) => item.name === itemName)) {
-        fireToast({ content: '이미 존재하는 아이템입니다.' });
-        return Promise.resolve(undefined);
+        throw new Error('이미 존재하는 아이템입니다.');
       }
 
       const requestData: createCardItemRequest = {

--- a/src/hooks/api/template/useCardItemMutation.ts
+++ b/src/hooks/api/template/useCardItemMutation.ts
@@ -62,6 +62,11 @@ const useCardItemMutation = () => {
       if (!currentCategory) throw new Error('카테고리를 생성해 주세요.');
       if (!currentTemplate) throw new Error('템플릿을 생성해 주세요.');
 
+      if (currentTemplate.items.find((item) => item.name === itemName)) {
+        fireToast({ content: '이미 존재하는 아이템입니다.' });
+        return Promise.resolve(undefined);
+      }
+
       const requestData: createCardItemRequest = {
         itemName,
         important,


### PR DESCRIPTION
<!-- 작성 예시 -->
<!-- # 해결하려는 문제가 무엇인가요? -->
<!-- - React v18 version update에 후 테스트에서 에러가 발생합니다.
  react-testing-library의 버전이 호환이 되지않아서 문제입니다. -->

<!-- # 어떻게 해결했나요? -->
<!-- - react-testing-library의 버전을 업데이트하고, react-test-renderer를 v18을 사용할 수 있도록 dev dependency로 설치해주었습니다. -->

## 🤔 해결하려는 문제가 무엇인가요?
- 중복된 아이템 생성 방지

## 🎉 어떻게 해결했나요?
- `useCardItemMutation`에서 `error`를 던지도록 핸들링했어요.
  - onError 시 토스트 메세지가 재생되어 이렇게 했어요

  - 원래 내부에서 토스트 메세지를 재생하고, `return Promise.resolve(undefined)`로 함수를 종료하려 했는데,
    바텀시트에서 onSuccess 시에 바텀시트가 닫치는데, 이를 따로 핸들링하는 건 DRY 하지 않다고 생각했어요
    > 근데 코드를 의도와 다르게 작성한 것 같아서 고민이긴해요 🤔 

### 📚 Attachment (Option)
<!-- - 이번 PR 의 Front 동작을 이해를 돕는 GIF 파일 첨부!
- 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함! -->

close #315 
 