### PR TITLE
토스트 메세지 디자인 변경 및 아이콘 인터페이스 추가

### DIFF
--- a/src/components/portal/ToastWrapper.tsx
+++ b/src/components/portal/ToastWrapper.tsx
@@ -50,5 +50,5 @@ const MotionToastMessage = styled(m.div)(
     borderRadius: '8px',
     textAlign: 'center',
   },
-  ({ theme }) => ({ ...theme.typographies.caption1, backgroundColor: theme.colors.gray5, color: theme.colors.white }),
+  ({ theme }) => ({ ...theme.typographies.caption1, backgroundColor: theme.colors.black, color: theme.colors.white }),
 );

--- a/src/components/portal/ToastWrapper.tsx
+++ b/src/components/portal/ToastWrapper.tsx
@@ -6,18 +6,21 @@ import useToast from '@/store/toast/useToast';
 
 const ToastWrapper = () => {
   const { toast } = useToast();
+  const isHaveIcon = Boolean(toast?.iconElement);
 
   return (
     <Wrapper>
       <AnimatePresence mode="wait">
         {toast && (
           <MotionToastMessage
-            key={toast.content ?? 'toast'}
+            key={toast.content}
             variants={defaultFadeInUpVariants}
             initial="initial"
             animate="animate"
             exit="exit"
+            isHaveIcon={isHaveIcon}
           >
+            {isHaveIcon && toast.iconElement}
             {toast.content}
           </MotionToastMessage>
         )}
@@ -42,13 +45,14 @@ const Wrapper = styled.div(
   ({ theme }) => ({ maxWidth: theme.size.maxWidth, padding: theme.size.layoutPadding }),
 );
 
-const MotionToastMessage = styled(m.div)(
+const MotionToastMessage = styled(m.div)<{ isHaveIcon: boolean }>(
   {
     width: '100%',
-    height: '48px',
-    padding: '12px 38px',
+    minHeight: '48px',
     borderRadius: '8px',
-    textAlign: 'center',
+    display: 'flex',
+    gap: '8px',
   },
   ({ theme }) => ({ ...theme.typographies.caption1, backgroundColor: theme.colors.black, color: theme.colors.white }),
+  ({ isHaveIcon }) => ({ padding: isHaveIcon ? '12px 16px' : '12px 18px' }),
 );

--- a/src/store/toast/toastState.ts
+++ b/src/store/toast/toastState.ts
@@ -1,9 +1,13 @@
+import { ReactElement } from 'react';
 import { atom } from 'recoil';
 
 interface Toast {
   id: string;
   content: string;
+  iconElement?: ReactElement;
 }
+
+export type ToastWithoutId = Omit<Toast, 'id'>;
 
 const toastState = atom<Toast | null>({
   key: 'toastState',

--- a/src/store/toast/useToast.ts
+++ b/src/store/toast/useToast.ts
@@ -1,10 +1,9 @@
 import { useCallback } from 'react';
 import { useRecoilState } from 'recoil';
 
-import toastState from './toastState';
+import toastState, { ToastWithoutId } from './toastState';
 
-interface FireToast {
-  content: string;
+interface FireToast extends ToastWithoutId {
   duration?: number;
 }
 
@@ -21,9 +20,9 @@ const useToast = () => {
     });
   }, []);
 
-  const fireToast = useCallback(({ content, duration = DEFAULT_DURATION }: FireToast) => {
+  const fireToast = useCallback(({ content, duration = DEFAULT_DURATION, iconElement }: FireToast) => {
     const id = new Date().getTime().toString();
-    setToast({ id, content });
+    setToast({ id, content, iconElement });
     setTimeout(() => removeToast(id), duration);
   }, []);
 


### PR DESCRIPTION
close #317 

## 🤔 해결하려는 문제가 무엇인가요?
- 토스트 메세지 스타일 변경 및 아이콘 대응

## 🎉 어떻게 해결했나요?
- toast에 `iconElement` 인터페이스를 추가했어요
  - 기존의 fireToast에서 같이 사용할 수 있도록 했어요
